### PR TITLE
feat: add distribution packaging pipeline

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -1,0 +1,80 @@
+name: Distribution Packages
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*"
+    branches:
+      - main
+      - preview
+      - dev
+
+jobs:
+  build:
+    name: Build ${{ matrix.platform }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - win32-x64
+          - win32-arm64
+          - linux-x64
+          - linux-arm64
+          - linux-armhf
+          - darwin-x64
+          - darwin-arm64
+          - alpine-x64
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.16.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "pnpm"
+
+      - name: Install 7-Zip
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y p7zip-full
+
+      - name: Restore portable dependency downloads
+        uses: actions/cache@v4
+        with:
+          path: dist/.downloads
+          key: ema-dist-downloads-${{ matrix.platform }}-${{ hashFiles('packages/ema-dist/src/download.ts') }}
+          restore-keys: |
+            ema-dist-downloads-${{ matrix.platform }}-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build WebUI standalone app
+        run: pnpm --filter ema-webui build
+
+      - name: Build distribution package
+        run: pnpm --filter ema-dist run build -- --platform ${{ matrix.platform }}
+
+      - name: Upload distribution artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ema-${{ matrix.platform }}-dist
+          if-no-files-found: error
+          path: |
+            dist/${{ matrix.platform }}/ema-${{ matrix.platform }}-*.7z
+            dist/${{ matrix.platform }}/ema-${{ matrix.platform }}-*.zip
+            dist/${{ matrix.platform }}/ema-${{ matrix.platform }}-*-installer.*
+            dist/${{ matrix.platform }}/*.SKIPPED.txt

--- a/package.json
+++ b/package.json
@@ -21,6 +21,12 @@
     "docs": "node scripts/docs.js --dev",
     "docs:gen": "node scripts/docs.js --gen",
     "docs:build": "node scripts/docs.js",
+    "dist:revision": "pnpm --filter ema-dist run revision",
+    "dist:download": "pnpm --filter ema-dist run download",
+    "dist:stage": "pnpm --filter ema-dist run stage",
+    "dist:pack": "pnpm --filter ema-dist run pack",
+    "dist:installers": "pnpm --filter ema-dist run installers",
+    "dist:build": "pnpm --filter ema-dist run build",
     "format": "prettier --write \"{packages,scripts}/**/*.{js,jsx,ts,tsx,json,css}\"",
     "format:check": "prettier --check \"{packages,scripts}/**/*.{js,jsx,ts,tsx,json,css}\""
   },

--- a/packages/ema-dist/README.md
+++ b/packages/ema-dist/README.md
@@ -1,0 +1,58 @@
+# ema-dist
+
+TypeScript distribution scripts for EverMemoryArchive.
+
+## Commands
+
+```bash
+pnpm --filter ema-webui build
+pnpm --filter ema-dist run revision
+pnpm --filter ema-dist run download -- --platform linux-x64
+pnpm --filter ema-dist run build -- --platform linux-x64
+```
+
+`download` writes portable runtime dependencies to:
+
+```text
+dist/$platform/EverMemoryArchive/portables
+```
+
+`build` writes CI-ready artifacts to `dist/$platform/`:
+
+```text
+ema-$platform-portable-$revision.7z
+ema-$platform-portable-$revision.zip
+ema-$platform-portable-$revision-installer.{ps1,run,command}
+ema-$platform-minimal-$revision.7z
+ema-$platform-minimal-$revision.zip
+ema-$platform-minimal-$revision-installer.{ps1,run,command}
+```
+
+The platform ids are:
+
+```text
+win32-x64
+win32-arm64
+linux-x64
+linux-arm64
+linux-armhf
+darwin-x64
+darwin-arm64
+alpine-x64
+```
+
+The revision is the nearest previous `v*` tag, or `v0.0.0` when no tag
+exists. Untagged commits append the 12-character commit hash, and dirty
+worktrees append `-dirty`.
+
+## Portable vs minimal
+
+`portable` bundles Node.js, MongoDB, and the 7-Zip command-line extractor under
+`portables/` when upstream binaries exist for the platform.
+
+`minimal` bundles only the built app and launch/configure scripts. It can use
+Node.js and MongoDB from configured paths, from `PATH`, or via `EMA_MONGO_URI`.
+
+MongoDB Community Server does not publish `linux-armhf` or Alpine/musl archives.
+For those platforms the CI produces minimal artifacts and a `.SKIPPED.txt` note
+for portable artifacts unless `--include-unsupported-portable` is passed.

--- a/packages/ema-dist/README.md
+++ b/packages/ema-dist/README.md
@@ -22,10 +22,10 @@ dist/$platform/EverMemoryArchive/portables
 ```text
 ema-$platform-portable-$revision.7z
 ema-$platform-portable-$revision.zip
-ema-$platform-portable-$revision-installer.{ps1,run,command}
+ema-$platform-portable-$revision-installer.{bat,run,command}
 ema-$platform-minimal-$revision.7z
 ema-$platform-minimal-$revision.zip
-ema-$platform-minimal-$revision-installer.{ps1,run,command}
+ema-$platform-minimal-$revision-installer.{bat,run,command}
 ```
 
 The platform ids are:

--- a/packages/ema-dist/README.md
+++ b/packages/ema-dist/README.md
@@ -53,6 +53,12 @@ worktrees append `-dirty`.
 `minimal` bundles only the built app and launch/configure scripts. It can use
 Node.js and MongoDB from configured paths, from `PATH`, or via `EMA_MONGO_URI`.
 
+Launchers open the WebUI in `EMA_OPEN_MODE=webview` by default. This uses an
+app-mode browser window without the normal browser toolbar when Edge, Chrome,
+Chromium, or Brave is available, and falls back to the system browser. During
+installation the user is asked whether to set `EMA_OPEN_MODE=browser` instead.
+`EMA_OPEN_MODE=none` starts only the server.
+
 MongoDB Community Server does not publish `linux-armhf` or Alpine/musl archives.
 For those platforms the CI produces minimal artifacts and a `.SKIPPED.txt` note
 for portable artifacts unless `--include-unsupported-portable` is passed.

--- a/packages/ema-dist/package.json
+++ b/packages/ema-dist/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "ema-dist",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "revision": "tsx src/cli.ts revision",
+    "download": "tsx src/cli.ts download",
+    "stage": "tsx src/cli.ts stage",
+    "pack": "tsx src/cli.ts pack",
+    "installers": "tsx src/cli.ts installers",
+    "build": "tsx src/cli.ts build"
+  }
+}

--- a/packages/ema-dist/package.json
+++ b/packages/ema-dist/package.json
@@ -3,11 +3,11 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "revision": "tsx src/cli.ts revision",
-    "download": "tsx src/cli.ts download",
-    "stage": "tsx src/cli.ts stage",
-    "pack": "tsx src/cli.ts pack",
-    "installers": "tsx src/cli.ts installers",
-    "build": "tsx src/cli.ts build"
+    "revision": "node --import tsx --import ./src/raw-import-loader.mjs src/cli.ts revision",
+    "download": "node --import tsx --import ./src/raw-import-loader.mjs src/cli.ts download",
+    "stage": "node --import tsx --import ./src/raw-import-loader.mjs src/cli.ts stage",
+    "pack": "node --import tsx --import ./src/raw-import-loader.mjs src/cli.ts pack",
+    "installers": "node --import tsx --import ./src/raw-import-loader.mjs src/cli.ts installers",
+    "build": "node --import tsx --import ./src/raw-import-loader.mjs src/cli.ts build"
   }
 }

--- a/packages/ema-dist/src/archive.ts
+++ b/packages/ema-dist/src/archive.ts
@@ -1,0 +1,122 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { commandExists, execFile } from "./shell";
+import { packageFileName, platformDistRoot } from "./paths";
+import type { PackageKind, Platform } from "./platforms";
+
+export async function findSevenZip(): Promise<string> {
+  const configured = process.env.EMA_DIST_7Z?.trim();
+  if (configured) {
+    return configured;
+  }
+  for (const command of ["7z", "7zz", "7za"]) {
+    if (await commandExists(command)) {
+      return command;
+    }
+  }
+  throw new Error(
+    "7-Zip was not found. Install 7z/7zz/7za or set EMA_DIST_7Z.",
+  );
+}
+
+export async function extractArchive(
+  archivePath: string,
+  destination: string,
+): Promise<void> {
+  const sevenZip = await findSevenZip();
+  await fs.rm(destination, { recursive: true, force: true });
+  await fs.mkdir(destination, { recursive: true });
+  const scratch = `${destination}.extracting`;
+  await fs.rm(scratch, { recursive: true, force: true });
+  await fs.mkdir(scratch, { recursive: true });
+
+  await execFile(sevenZip, ["x", archivePath, `-o${scratch}`, "-y"]);
+  const innerTar = await findFirstFile(scratch, (fileName) =>
+    fileName.endsWith(".tar"),
+  );
+  if (innerTar) {
+    await execFile(sevenZip, ["x", innerTar, `-o${scratch}`, "-y"]);
+    await fs.rm(innerTar, { force: true });
+  }
+
+  await copySingleRootContents(scratch, destination);
+  await fs.rm(scratch, { recursive: true, force: true });
+}
+
+export async function createPackageArchives(
+  platform: Platform,
+  kind: PackageKind,
+  revision: string,
+  sourceRoot: string,
+): Promise<string[]> {
+  const sevenZip = await findSevenZip();
+  const outDir = platformDistRoot(platform);
+  await fs.mkdir(outDir, { recursive: true });
+  const parent = path.dirname(sourceRoot);
+  const rootName = path.basename(sourceRoot);
+  const outputs = [
+    path.join(outDir, packageFileName(platform, kind, revision, "7z")),
+    path.join(outDir, packageFileName(platform, kind, revision, "zip")),
+  ];
+
+  for (const output of outputs) {
+    await fs.rm(output, { force: true });
+  }
+
+  await execFile(sevenZip, ["a", "-t7z", "-mx=9", outputs[0], rootName], {
+    cwd: parent,
+  });
+  await execFile(sevenZip, ["a", "-tzip", "-mx=9", outputs[1], rootName], {
+    cwd: parent,
+  });
+
+  return outputs;
+}
+
+async function findFirstFile(
+  root: string,
+  predicate: (fileName: string) => boolean,
+): Promise<string | null> {
+  const entries = await fs.readdir(root, { withFileTypes: true });
+  for (const entry of entries) {
+    const entryPath = path.join(root, entry.name);
+    if (entry.isDirectory()) {
+      const nested = await findFirstFile(entryPath, predicate);
+      if (nested) {
+        return nested;
+      }
+      continue;
+    }
+    if (predicate(entry.name)) {
+      return entryPath;
+    }
+  }
+  return null;
+}
+
+async function copySingleRootContents(
+  source: string,
+  destination: string,
+): Promise<void> {
+  const entries = await fs.readdir(source, { withFileTypes: true });
+  const visibleEntries = entries.filter((entry) => entry.name !== "__MACOSX");
+  if (visibleEntries.length === 1 && visibleEntries[0].isDirectory()) {
+    await fs.cp(path.join(source, visibleEntries[0].name), destination, {
+      recursive: true,
+      force: true,
+      preserveTimestamps: true,
+    });
+    return;
+  }
+  for (const entry of visibleEntries) {
+    await fs.cp(
+      path.join(source, entry.name),
+      path.join(destination, entry.name),
+      {
+        recursive: true,
+        force: true,
+        preserveTimestamps: true,
+      },
+    );
+  }
+}

--- a/packages/ema-dist/src/cli.ts
+++ b/packages/ema-dist/src/cli.ts
@@ -1,0 +1,224 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { parseArgs } from "node:util";
+import { createPackageArchives } from "./archive";
+import { downloadPortableDependencies } from "./download";
+import { createSelfInstaller } from "./installer";
+import { packageFileName, platformDistRoot, stageRoot } from "./paths";
+import {
+  assertPackageKind,
+  getPlatform,
+  hostPlatformId,
+  PLATFORM_IDS,
+  PLATFORMS,
+  type PackageKind,
+  type Platform,
+} from "./platforms";
+import { resolveRevision } from "./revision";
+import { refreshMinimalStageFromPortable, stagePackage } from "./stage";
+
+const HELP = `
+Usage:
+  pnpm --filter ema-dist run revision
+  pnpm --filter ema-dist run download -- --platform linux-x64
+  pnpm --filter ema-dist run stage -- --platform linux-x64 --kind portable
+  pnpm --filter ema-dist run pack -- --platform linux-x64 --kind portable
+  pnpm --filter ema-dist run installers -- --platform linux-x64 --kind minimal
+  pnpm --filter ema-dist run build -- --platform linux-x64
+
+Options:
+  --platform <id>                 Target platform. Defaults to the host platform.
+  --all-platforms                 Run for every supported platform id.
+  --kind <portable|minimal>        Package kind for stage/pack/installers.
+  --revision <revision>           Override computed git revision.
+  --include-unsupported-portable   Also package portable archives when MongoDB cannot be bundled.
+  --help                          Show this help.
+
+Platforms:
+  ${PLATFORM_IDS.join(", ")}
+`;
+
+async function main(): Promise<void> {
+  const argv = process.argv.slice(2);
+  const command = argv[0]?.startsWith("-") ? "help" : (argv[0] ?? "help");
+  const rawArgsWithSeparator = argv[0]?.startsWith("-") ? argv : argv.slice(1);
+  const rawArgs =
+    rawArgsWithSeparator[0] === "--"
+      ? rawArgsWithSeparator.slice(1)
+      : rawArgsWithSeparator;
+  const args = parseArgs({
+    args: rawArgs,
+    options: {
+      platform: { type: "string" },
+      "all-platforms": { type: "boolean", default: false },
+      kind: { type: "string" },
+      revision: { type: "string" },
+      "include-unsupported-portable": { type: "boolean", default: false },
+      help: { type: "boolean", short: "h", default: false },
+    },
+    allowPositionals: false,
+  });
+
+  if (args.values.help || command === "help") {
+    process.stdout.write(HELP.trimStart());
+    return;
+  }
+
+  const revision = args.values.revision ?? (await resolveRevision());
+  const platforms = resolvePlatforms(
+    args.values.platform,
+    args.values["all-platforms"],
+  );
+  const includeUnsupportedPortable = Boolean(
+    args.values["include-unsupported-portable"],
+  );
+  const kind = args.values.kind
+    ? assertPackageKind(args.values.kind)
+    : undefined;
+
+  switch (command) {
+    case "revision":
+      process.stdout.write(`${revision}\n`);
+      return;
+    case "download":
+      await runForPlatforms(platforms, async (platform) => {
+        await downloadPortableDependencies(platform);
+      });
+      return;
+    case "stage":
+      await requireKind(kind, async (packageKind) => {
+        await runForPlatforms(platforms, async (platform) => {
+          await stagePackage({ platform, kind: packageKind, revision });
+        });
+      });
+      return;
+    case "pack":
+      await requireKind(kind, async (packageKind) => {
+        await runForPlatforms(platforms, async (platform) => {
+          await packKind(platform, packageKind, revision);
+        });
+      });
+      return;
+    case "installers":
+      await requireKind(kind, async (packageKind) => {
+        await runForPlatforms(platforms, async (platform) => {
+          await createSelfInstaller(platform, packageKind, revision);
+        });
+      });
+      return;
+    case "build":
+      await runForPlatforms(platforms, async (platform) => {
+        await buildPlatform(platform, revision, includeUnsupportedPortable);
+      });
+      return;
+    case "list-platforms":
+      for (const platform of PLATFORMS) {
+        process.stdout.write(`${platform.id}\t${platform.label}\n`);
+      }
+      return;
+    default:
+      throw new Error(`Unknown ema-dist command '${command}'.\n\n${HELP}`);
+  }
+}
+
+async function buildPlatform(
+  platform: Platform,
+  revision: string,
+  includeUnsupportedPortable: boolean,
+): Promise<void> {
+  process.stdout.write(`Staging ${platform.id} portable package\n`);
+  await stagePackage({ platform, kind: "portable", revision });
+  await downloadPortableDependencies(platform);
+
+  const packagePortable = platform.canBundleMongo || includeUnsupportedPortable;
+  if (packagePortable) {
+    await packKind(platform, "portable", revision);
+    await createSelfInstaller(platform, "portable", revision);
+  } else {
+    process.stdout.write(
+      `Skipping ${platform.id} portable package: ${platform.mongoNote}\n`,
+    );
+    await writeSkipNote(platform, revision);
+  }
+
+  process.stdout.write(`Staging ${platform.id} minimal package\n`);
+  await refreshMinimalStageFromPortable(platform, revision);
+  await packKind(platform, "minimal", revision);
+  await createSelfInstaller(platform, "minimal", revision);
+}
+
+async function packKind(
+  platform: Platform,
+  kind: PackageKind,
+  revision: string,
+): Promise<void> {
+  const root = stageRoot(platform, kind);
+  await ensureStageExists(root, platform, kind);
+  const outputs = await createPackageArchives(platform, kind, revision, root);
+  for (const output of outputs) {
+    process.stdout.write(`Wrote ${output}\n`);
+  }
+}
+
+async function writeSkipNote(
+  platform: Platform,
+  revision: string,
+): Promise<void> {
+  const outDir = platformDistRoot(platform);
+  await fs.mkdir(outDir, { recursive: true });
+  const skippedName = packageFileName(platform, "portable", revision, "7z");
+  await fs.writeFile(
+    path.join(outDir, `${skippedName}.SKIPPED.txt`),
+    `${platform.mongoNote}\nUse the minimal package and configure MongoDB from PATH or EMA_MONGO_URI.\n`,
+  );
+}
+
+async function ensureStageExists(
+  root: string,
+  platform: Platform,
+  kind: PackageKind,
+): Promise<void> {
+  try {
+    await fs.access(root);
+  } catch {
+    throw new Error(
+      `Missing ${kind} stage for ${platform.id}: ${root}. Run stage or build first.`,
+    );
+  }
+}
+
+function resolvePlatforms(
+  platformArg: string | undefined,
+  allPlatforms: boolean | undefined,
+): Platform[] {
+  if (allPlatforms) {
+    return [...PLATFORMS];
+  }
+  return [getPlatform(platformArg ?? hostPlatformId())];
+}
+
+async function requireKind(
+  kind: PackageKind | undefined,
+  callback: (kind: PackageKind) => Promise<void>,
+): Promise<void> {
+  if (!kind) {
+    throw new Error("--kind <portable|minimal> is required for this command.");
+  }
+  await callback(kind);
+}
+
+async function runForPlatforms(
+  platforms: readonly Platform[],
+  callback: (platform: Platform) => Promise<void>,
+): Promise<void> {
+  for (const platform of platforms) {
+    await callback(platform);
+  }
+}
+
+main().catch((error: unknown) => {
+  process.stderr.write(
+    `${error instanceof Error ? error.message : String(error)}\n`,
+  );
+  process.exit(1);
+});

--- a/packages/ema-dist/src/download.ts
+++ b/packages/ema-dist/src/download.ts
@@ -1,0 +1,326 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { extractArchive } from "./archive";
+import { downloadsRoot, portableStageRoot } from "./paths";
+import type { Platform } from "./platforms";
+
+interface RuntimeVersions {
+  readonly node: string;
+  readonly mongodb: string;
+  readonly sevenZip: string;
+}
+
+interface DownloadedDependency {
+  readonly name: "node" | "mongodb" | "7zip";
+  readonly url: string;
+  readonly bundled: boolean;
+  readonly note?: string;
+}
+
+export async function downloadPortableDependencies(
+  platform: Platform,
+): Promise<DownloadedDependency[]> {
+  const versions = await resolveRuntimeVersions();
+  const stageRoot = portableStageRoot(platform);
+  const portablesRoot = path.join(stageRoot, "portables");
+  await fs.mkdir(portablesRoot, { recursive: true });
+
+  const dependencies: DownloadedDependency[] = [];
+  const node = nodeArtifact(platform, versions.node);
+  await downloadAndExtract(
+    node.url,
+    node.fileName,
+    path.join(portablesRoot, "node"),
+  );
+  dependencies.push({ name: "node", url: node.url, bundled: true });
+
+  if (platform.canBundleMongo) {
+    const mongodb = mongodbArtifact(platform, versions.mongodb);
+    await downloadAndExtract(
+      mongodb.url,
+      mongodb.fileName,
+      path.join(portablesRoot, "mongodb"),
+    );
+    dependencies.push({
+      name: "mongodb",
+      url: mongodb.url,
+      bundled: true,
+      note: platform.mongoNote,
+    });
+  } else {
+    dependencies.push({
+      name: "mongodb",
+      url: "",
+      bundled: false,
+      note: platform.mongoNote,
+    });
+  }
+
+  const sevenZip = sevenZipArtifact(platform, versions.sevenZip);
+  const sevenZipArchive = await downloadFile(sevenZip.url, sevenZip.fileName);
+  const sevenZipDest = path.join(portablesRoot, "7zip");
+  if (platform.os === "win32") {
+    await extractWindowsSevenZip(sevenZipArchive, sevenZipDest);
+  } else {
+    await extractArchive(sevenZipArchive, sevenZipDest);
+    await chmodIfExists(path.join(sevenZipDest, "7zz"), 0o755);
+  }
+  dependencies.push({ name: "7zip", url: sevenZip.url, bundled: true });
+
+  await fs.writeFile(
+    path.join(portablesRoot, "manifest.json"),
+    `${JSON.stringify(
+      {
+        platform: platform.id,
+        label: platform.label,
+        versions,
+        dependencies,
+      },
+      null,
+      2,
+    )}\n`,
+  );
+
+  await chmodIfExists(path.join(portablesRoot, "node", "bin", "node"), 0o755);
+  await chmodIfExists(
+    path.join(portablesRoot, "mongodb", "bin", "mongod"),
+    0o755,
+  );
+  return dependencies;
+}
+
+export async function resolveRuntimeVersions(): Promise<RuntimeVersions> {
+  const requestedNode = process.env.EMA_DIST_NODE_VERSION?.trim() || "22";
+  return {
+    node: await resolveNodeVersion(requestedNode),
+    mongodb: process.env.EMA_DIST_MONGODB_VERSION?.trim() || "8.2.7",
+    sevenZip: process.env.EMA_DIST_7ZIP_VERSION?.trim() || "26.01",
+  };
+}
+
+async function resolveNodeVersion(requested: string): Promise<string> {
+  const normalized = requested.replace(/^v/u, "");
+  if (/^\d+\.\d+\.\d+$/u.test(normalized)) {
+    return normalized;
+  }
+  if (!/^\d+$/u.test(normalized)) {
+    throw new Error(
+      `EMA_DIST_NODE_VERSION must be a major version or exact semver, got '${requested}'.`,
+    );
+  }
+  const response = await fetch("https://nodejs.org/dist/index.json");
+  if (!response.ok) {
+    throw new Error(
+      `Failed to resolve Node.js ${requested}: ${response.status} ${response.statusText}`,
+    );
+  }
+  const releases = (await response.json()) as Array<{ version: string }>;
+  const major = Number(normalized);
+  const matching = releases
+    .map((release) => release.version.replace(/^v/u, ""))
+    .filter((version) => Number(version.split(".")[0]) === major)
+    .sort(compareSemverDesc);
+  if (!matching[0]) {
+    throw new Error(`No Node.js release found for major ${major}.`);
+  }
+  return matching[0];
+}
+
+function compareSemverDesc(left: string, right: string): number {
+  const leftParts = left.split(".").map(Number);
+  const rightParts = right.split(".").map(Number);
+  for (let index = 0; index < 3; index += 1) {
+    const delta = (rightParts[index] ?? 0) - (leftParts[index] ?? 0);
+    if (delta !== 0) {
+      return delta;
+    }
+  }
+  return 0;
+}
+
+function nodeArtifact(
+  platform: Platform,
+  version: string,
+): { url: string; fileName: string } {
+  let target: string;
+  let extension: "zip" | "tar.gz" | "tar.xz";
+  if (platform.os === "win32") {
+    target = platform.arch === "arm64" ? "win-arm64" : "win-x64";
+    extension = "zip";
+  } else if (platform.os === "darwin") {
+    target = platform.arch === "arm64" ? "darwin-arm64" : "darwin-x64";
+    extension = "tar.gz";
+  } else if (platform.id === "linux-armhf") {
+    target = "linux-armv7l";
+    extension = "tar.xz";
+  } else if (platform.id === "alpine-x64") {
+    target = "linux-x64-musl";
+    extension = "tar.xz";
+    const fileName = `node-v${version}-${target}.${extension}`;
+    return {
+      fileName,
+      url: `https://unofficial-builds.nodejs.org/download/release/v${version}/${fileName}`,
+    };
+  } else {
+    target = platform.arch === "arm64" ? "linux-arm64" : "linux-x64";
+    extension = "tar.xz";
+  }
+  const fileName = `node-v${version}-${target}.${extension}`;
+  return {
+    fileName,
+    url: `https://nodejs.org/dist/v${version}/${fileName}`,
+  };
+}
+
+function mongodbArtifact(
+  platform: Platform,
+  version: string,
+): { url: string; fileName: string } {
+  let fileName: string;
+  if (platform.os === "win32") {
+    fileName = `mongodb-windows-x86_64-${version}.zip`;
+    return {
+      fileName,
+      url: `https://fastdl.mongodb.org/windows/${fileName}`,
+    };
+  }
+  if (platform.os === "darwin") {
+    const arch = platform.arch === "arm64" ? "arm64" : "x86_64";
+    fileName = `mongodb-macos-${arch}-${version}.tgz`;
+    return {
+      fileName,
+      url: `https://fastdl.mongodb.org/osx/${fileName}`,
+    };
+  }
+  if (platform.arch === "arm64") {
+    fileName = `mongodb-linux-aarch64-ubuntu2204-${version}.tgz`;
+  } else {
+    fileName = `mongodb-linux-x86_64-debian12-${version}.tgz`;
+  }
+  return {
+    fileName,
+    url: `https://fastdl.mongodb.org/linux/${fileName}`,
+  };
+}
+
+function sevenZipArtifact(
+  platform: Platform,
+  version: string,
+): { url: string; fileName: string } {
+  const shortVersion = version.replace(/\D/gu, "");
+  if (platform.os === "win32") {
+    const fileName = `7z${shortVersion}-extra.7z`;
+    return {
+      fileName,
+      url: `https://www.7-zip.org/a/${fileName}`,
+    };
+  }
+  if (platform.os === "darwin") {
+    const fileName = `7z${shortVersion}-mac.tar.xz`;
+    return {
+      fileName,
+      url: `https://www.7-zip.org/a/${fileName}`,
+    };
+  }
+  const arch =
+    platform.arch === "arm64"
+      ? "arm64"
+      : platform.arch === "armhf"
+        ? "arm"
+        : "x64";
+  const fileName = `7z${shortVersion}-linux-${arch}.tar.xz`;
+  return {
+    fileName,
+    url: `https://www.7-zip.org/a/${fileName}`,
+  };
+}
+
+async function downloadAndExtract(
+  url: string,
+  fileName: string,
+  destination: string,
+): Promise<void> {
+  const archivePath = await downloadFile(url, fileName);
+  await extractArchive(archivePath, destination);
+}
+
+async function downloadFile(url: string, fileName: string): Promise<string> {
+  const destination = path.join(downloadsRoot(), fileName);
+  const existing = await fileExists(destination);
+  if (existing) {
+    return destination;
+  }
+  await fs.mkdir(path.dirname(destination), { recursive: true });
+  process.stdout.write(`Downloading ${url}\n`);
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(
+      `Failed to download ${url}: ${response.status} ${response.statusText}`,
+    );
+  }
+  const bytes = new Uint8Array(await response.arrayBuffer());
+  await fs.writeFile(destination, bytes);
+  return destination;
+}
+
+async function extractWindowsSevenZip(
+  archivePath: string,
+  destination: string,
+): Promise<void> {
+  const scratch = `${destination}.extracting`;
+  await extractArchive(archivePath, scratch);
+  await fs.rm(destination, { recursive: true, force: true });
+  await fs.mkdir(destination, { recursive: true });
+  const candidate =
+    (await findFile(scratch, (filePath) =>
+      filePath.toLowerCase().endsWith(`${path.sep}x64${path.sep}7za.exe`),
+    )) ??
+    (await findFile(scratch, (filePath) =>
+      filePath.toLowerCase().endsWith(`${path.sep}7za.exe`),
+    ));
+  if (!candidate) {
+    throw new Error(`Could not find 7za.exe in ${archivePath}.`);
+  }
+  await fs.copyFile(candidate, path.join(destination, "7za.exe"));
+  await fs.rm(scratch, { recursive: true, force: true });
+}
+
+async function findFile(
+  root: string,
+  predicate: (filePath: string) => boolean,
+): Promise<string | null> {
+  const entries = await fs.readdir(root, { withFileTypes: true });
+  for (const entry of entries) {
+    const entryPath = path.join(root, entry.name);
+    if (entry.isDirectory()) {
+      const nested = await findFile(entryPath, predicate);
+      if (nested) {
+        return nested;
+      }
+      continue;
+    }
+    if (predicate(entryPath)) {
+      return entryPath;
+    }
+  }
+  return null;
+}
+
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    const stat = await fs.stat(filePath);
+    return stat.size > 0;
+  } catch {
+    return false;
+  }
+}
+
+async function chmodIfExists(filePath: string, mode: number): Promise<void> {
+  try {
+    await fs.chmod(filePath, mode);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw error;
+    }
+  }
+}

--- a/packages/ema-dist/src/installer.ts
+++ b/packages/ema-dist/src/installer.ts
@@ -7,6 +7,9 @@ import {
   portableStageRoot,
 } from "./paths";
 import type { PackageKind, Platform } from "./platforms";
+import installerCmdTemplate from "./templates/installer.cmd?raw";
+import installerShTemplate from "./templates/installer.sh?raw";
+import { renderTemplate } from "./templates";
 
 export async function createSelfInstaller(
   platform: Platform,
@@ -52,119 +55,12 @@ function posixInstaller(
   archive: Buffer,
   sevenZip: Buffer,
 ): string {
-  return `#!/usr/bin/env bash
-set -euo pipefail
-
-PLATFORM="${platform.id}"
-KIND="${kind}"
-TMP_DIR="$(mktemp -d)"
-cleanup() {
-  rm -rf "$TMP_DIR"
-}
-trap cleanup EXIT INT TERM
-
-extract_section() {
-  awk "/^__EMA_$1_BEGIN__$/ {flag=1; next} /^__EMA_$1_END__$/ {flag=0} flag {print}" "$0"
-}
-
-decode_section() {
-  if base64 --help 2>/dev/null | grep -q -- "--decode"; then
-    extract_section "$1" | base64 --decode > "$2"
-  else
-    extract_section "$1" | base64 -D > "$2"
-  fi
-}
-
-SEVENZIP="$TMP_DIR/7zz"
-ARCHIVE="$TMP_DIR/payload.7z"
-decode_section SEVENZIP "$SEVENZIP"
-decode_section ARCHIVE "$ARCHIVE"
-chmod +x "$SEVENZIP"
-
-DEFAULT_PARENT="\${HOME:-.}"
-printf "Install parent directory [%s]: " "$DEFAULT_PARENT"
-read -r INSTALL_PARENT
-INSTALL_PARENT="\${INSTALL_PARENT:-$DEFAULT_PARENT}"
-mkdir -p "$INSTALL_PARENT"
-
-"$SEVENZIP" x "$ARCHIVE" "-o$INSTALL_PARENT" -y
-APP_DIR="$INSTALL_PARENT/EverMemoryArchive"
-chmod +x "$APP_DIR/start.sh" "$APP_DIR/configure.sh" 2>/dev/null || true
-
-NODE_PATH_INPUT=""
-MONGO_PATH_INPUT=""
-MONGO_URI_INPUT=""
-if [ "$KIND" = "minimal" ]; then
-  printf "Node executable path [PATH]: "
-  read -r NODE_PATH_INPUT
-  printf "mongod executable path [PATH]: "
-  read -r MONGO_PATH_INPUT
-  printf "MongoDB URI [start local mongod]: "
-  read -r MONGO_URI_INPUT
-fi
-
-OPEN_MODE="webview"
-printf "Use default browser instead of app/webview window? [y/N]: "
-read -r USE_BROWSER_INPUT
-case "$USE_BROWSER_INPUT" in
-  y|Y|yes|YES)
-    OPEN_MODE="browser"
-    ;;
-esac
-
-cat > "$APP_DIR/ema-runtime.sh" <<EOF
-export EMA_NODE_PATH="$NODE_PATH_INPUT"
-export EMA_MONGO_PATH="$MONGO_PATH_INPUT"
-export EMA_MONGO_URI="$MONGO_URI_INPUT"
-export EMA_HOST="127.0.0.1"
-export EMA_PORT="3000"
-export EMA_OPEN_MODE="$OPEN_MODE"
-EOF
-
-printf "Create shortcut? [Y/n]: "
-read -r CREATE_SHORTCUT
-CREATE_SHORTCUT="\${CREATE_SHORTCUT:-Y}"
-case "$CREATE_SHORTCUT" in
-  y|Y|yes|YES)
-    if [ "$PLATFORM" = "darwin-x64" ] || [ "$PLATFORM" = "darwin-arm64" ]; then
-      SHORTCUT="$HOME/Desktop/EverMemoryArchive.command"
-      cat > "$SHORTCUT" <<EOF
-#!/usr/bin/env bash
-cd "$APP_DIR"
-exec ./start.sh
-EOF
-      chmod +x "$SHORTCUT"
-    else
-      mkdir -p "$HOME/.local/share/applications"
-      DESKTOP_FILE="$HOME/.local/share/applications/evermemoryarchive.desktop"
-      cat > "$DESKTOP_FILE" <<EOF
-[Desktop Entry]
-Type=Application
-Name=EverMemoryArchive
-Exec=$APP_DIR/start.sh
-Path=$APP_DIR
-Terminal=true
-Categories=Utility;
-EOF
-      if [ -d "$HOME/Desktop" ]; then
-        cp "$DESKTOP_FILE" "$HOME/Desktop/EverMemoryArchive.desktop"
-        chmod +x "$HOME/Desktop/EverMemoryArchive.desktop"
-      fi
-    fi
-    ;;
-esac
-
-echo "Installed EverMemoryArchive to $APP_DIR"
-echo "Run $APP_DIR/start.sh to start."
-exit 0
-
-__EMA_SEVENZIP_BEGIN__
-${wrapBase64(sevenZip)}
-__EMA_SEVENZIP_END__
-__EMA_ARCHIVE_BEGIN__
-${wrapBase64(archive)}
-__EMA_ARCHIVE_END__
-`;
+  return renderInstallerTemplate(installerShTemplate, {
+    archive,
+    kind,
+    platform,
+    sevenZip,
+  });
 }
 
 function windowsInstaller(
@@ -173,115 +69,29 @@ function windowsInstaller(
   archive: Buffer,
   sevenZip: Buffer,
 ): string {
-  return `@echo off
-setlocal EnableExtensions
-set "PLATFORM=${platform.id}"
-set "KIND=${kind}"
-set "TMP_DIR=%TEMP%\\ema-installer-%RANDOM%%RANDOM%%RANDOM%"
-set "EXIT_CODE=0"
+  return renderInstallerTemplate(installerCmdTemplate, {
+    archive,
+    kind,
+    platform,
+    sevenZip,
+  });
+}
 
-mkdir "%TMP_DIR%" >nul 2>nul
-if errorlevel 1 (
-  echo Failed to create temporary directory: "%TMP_DIR%"
-  exit /b 1
-)
-
-set "SEVENZIP_B64=%TMP_DIR%\\7za.b64"
-set "ARCHIVE_B64=%TMP_DIR%\\payload.b64"
-set "SEVENZIP_PATH=%TMP_DIR%\\7za.exe"
-set "ARCHIVE_PATH=%TMP_DIR%\\payload.7z"
-
-call :extract_section EMA_SEVENZIP "%SEVENZIP_B64%" || goto fail
-call :decode_base64 "%SEVENZIP_B64%" "%SEVENZIP_PATH%" || goto fail
-call :extract_section EMA_ARCHIVE "%ARCHIVE_B64%" || goto fail
-call :decode_base64 "%ARCHIVE_B64%" "%ARCHIVE_PATH%" || goto fail
-
-set "DEFAULT_PARENT=%USERPROFILE%"
-set /p INSTALL_PARENT=Install parent directory [%DEFAULT_PARENT%]: 
-if not defined INSTALL_PARENT set "INSTALL_PARENT=%DEFAULT_PARENT%"
-mkdir "%INSTALL_PARENT%" >nul 2>nul
-
-"%SEVENZIP_PATH%" x "%ARCHIVE_PATH%" "-o%INSTALL_PARENT%" -y
-if errorlevel 1 goto fail
-
-set "APP_DIR=%INSTALL_PARENT%\\EverMemoryArchive"
-set "NODE_PATH_INPUT="
-set "MONGO_PATH_INPUT="
-set "MONGO_URI_INPUT="
-if /I "%KIND%"=="minimal" (
-  set /p NODE_PATH_INPUT=Node executable path [PATH]: 
-  set /p MONGO_PATH_INPUT=mongod executable path [PATH]: 
-  set /p MONGO_URI_INPUT=MongoDB URI [start local mongod]: 
-)
-
-set "OPEN_MODE=webview"
-set /p USE_BROWSER=Use default browser instead of app/webview window? [y/N]: 
-if /I "%USE_BROWSER%"=="y" set "OPEN_MODE=browser"
-if /I "%USE_BROWSER%"=="yes" set "OPEN_MODE=browser"
-
-> "%APP_DIR%\\ema-runtime.cmd" echo set "EMA_NODE_PATH=%NODE_PATH_INPUT%"
->> "%APP_DIR%\\ema-runtime.cmd" echo set "EMA_MONGO_PATH=%MONGO_PATH_INPUT%"
->> "%APP_DIR%\\ema-runtime.cmd" echo set "EMA_MONGO_URI=%MONGO_URI_INPUT%"
->> "%APP_DIR%\\ema-runtime.cmd" echo set "EMA_HOST=127.0.0.1"
->> "%APP_DIR%\\ema-runtime.cmd" echo set "EMA_PORT=3000"
->> "%APP_DIR%\\ema-runtime.cmd" echo set "EMA_OPEN_MODE=%OPEN_MODE%"
-
-set /p CREATE_SHORTCUT=Create desktop shortcut? [Y/n]: 
-if not defined CREATE_SHORTCUT set "CREATE_SHORTCUT=Y"
-if /I "%CREATE_SHORTCUT%"=="y" call :create_shortcut
-if /I "%CREATE_SHORTCUT%"=="yes" call :create_shortcut
-
-echo Installed EverMemoryArchive to "%APP_DIR%"
-echo Run "%APP_DIR%\\start.cmd" to start.
-goto cleanup
-
-:fail
-set "EXIT_CODE=1"
-echo Installation failed.
-goto cleanup
-
-:cleanup
-if exist "%TMP_DIR%" rd /s /q "%TMP_DIR%" >nul 2>nul
-exit /b %EXIT_CODE%
-
-:decode_base64
-certutil -f -decode "%~1" "%~2" >nul 2>nul
-if errorlevel 1 (
-  echo Failed to decode "%~1". certutil.exe is required on Windows.
-  exit /b 1
-)
-exit /b 0
-
-:extract_section
-set "SECTION=%~1"
-set "OUT_FILE=%~2"
-set "INSIDE="
-> "%OUT_FILE%" (
-  for /f "usebackq delims=" %%L in ("%~f0") do (
-    if "%%L"=="__%SECTION%_END__" set "INSIDE="
-    if defined INSIDE echo(%%L
-    if "%%L"=="__%SECTION%_BEGIN__" set "INSIDE=1"
-  )
-)
-exit /b 0
-
-:create_shortcut
-set "DESKTOP=%USERPROFILE%\\Desktop"
-if not exist "%DESKTOP%" exit /b 0
-set "SHORTCUT=%DESKTOP%\\EverMemoryArchive.cmd"
-> "%SHORTCUT%" echo @echo off
->> "%SHORTCUT%" echo cd /d "%APP_DIR%"
->> "%SHORTCUT%" echo call "%APP_DIR%\\start.cmd"
-echo Created "%SHORTCUT%"
-exit /b 0
-
-__EMA_SEVENZIP_BEGIN__
-${wrapBase64(sevenZip)}
-__EMA_SEVENZIP_END__
-__EMA_ARCHIVE_BEGIN__
-${wrapBase64(archive)}
-__EMA_ARCHIVE_END__
-`;
+function renderInstallerTemplate(
+  template: string,
+  options: {
+    readonly archive: Buffer;
+    readonly kind: PackageKind;
+    readonly platform: Platform;
+    readonly sevenZip: Buffer;
+  },
+): string {
+  return renderTemplate(template, {
+    archiveBase64: wrapBase64(options.archive),
+    kind: options.kind,
+    platformId: options.platform.id,
+    sevenZipBase64: wrapBase64(options.sevenZip),
+  });
 }
 
 function wrapBase64(value: Buffer): string {

--- a/packages/ema-dist/src/installer.ts
+++ b/packages/ema-dist/src/installer.ts
@@ -91,6 +91,9 @@ mkdir -p "$INSTALL_PARENT"
 APP_DIR="$INSTALL_PARENT/EverMemoryArchive"
 chmod +x "$APP_DIR/start.sh" "$APP_DIR/configure.sh" 2>/dev/null || true
 
+NODE_PATH_INPUT=""
+MONGO_PATH_INPUT=""
+MONGO_URI_INPUT=""
 if [ "$KIND" = "minimal" ]; then
   printf "Node executable path [PATH]: "
   read -r NODE_PATH_INPUT
@@ -98,14 +101,25 @@ if [ "$KIND" = "minimal" ]; then
   read -r MONGO_PATH_INPUT
   printf "MongoDB URI [start local mongod]: "
   read -r MONGO_URI_INPUT
-  cat > "$APP_DIR/ema-runtime.sh" <<EOF
+fi
+
+OPEN_MODE="webview"
+printf "Use default browser instead of app/webview window? [y/N]: "
+read -r USE_BROWSER_INPUT
+case "$USE_BROWSER_INPUT" in
+  y|Y|yes|YES)
+    OPEN_MODE="browser"
+    ;;
+esac
+
+cat > "$APP_DIR/ema-runtime.sh" <<EOF
 export EMA_NODE_PATH="$NODE_PATH_INPUT"
 export EMA_MONGO_PATH="$MONGO_PATH_INPUT"
 export EMA_MONGO_URI="$MONGO_URI_INPUT"
 export EMA_HOST="127.0.0.1"
 export EMA_PORT="3000"
+export EMA_OPEN_MODE="$OPEN_MODE"
 EOF
-fi
 
 printf "Create shortcut? [Y/n]: "
 read -r CREATE_SHORTCUT
@@ -190,19 +204,30 @@ try {
   }
 
   $AppDir = Join-Path $InstallParent "EverMemoryArchive"
+  $NodePath = ""
+  $MongoPath = ""
+  $MongoUri = ""
   if ($Kind -eq "minimal") {
     $NodePath = Read-Host "Node executable path [PATH]"
     $MongoPath = Read-Host "mongod executable path [PATH]"
     $MongoUri = Read-Host "MongoDB URI [start local mongod]"
-    $RuntimeCmd = @(
-      'set "EMA_NODE_PATH=' + ($NodePath -replace '"', '') + '"',
-      'set "EMA_MONGO_PATH=' + ($MongoPath -replace '"', '') + '"',
-      'set "EMA_MONGO_URI=' + ($MongoUri -replace '"', '') + '"',
-      'set "EMA_HOST=127.0.0.1"',
-      'set "EMA_PORT=3000"'
-    ) -join [Environment]::NewLine
-    Set-Content -LiteralPath (Join-Path $AppDir "ema-runtime.cmd") -Value $RuntimeCmd -Encoding ASCII
   }
+
+  $UseBrowser = Read-Host "Use default browser instead of app/webview window? [y/N]"
+  $OpenMode = "webview"
+  if ($UseBrowser -match "^(y|yes)$") {
+    $OpenMode = "browser"
+  }
+
+  $RuntimeCmd = @(
+    'set "EMA_NODE_PATH=' + ($NodePath -replace '"', '') + '"',
+    'set "EMA_MONGO_PATH=' + ($MongoPath -replace '"', '') + '"',
+    'set "EMA_MONGO_URI=' + ($MongoUri -replace '"', '') + '"',
+    'set "EMA_HOST=127.0.0.1"',
+    'set "EMA_PORT=3000"',
+    'set "EMA_OPEN_MODE=' + $OpenMode + '"'
+  ) -join [Environment]::NewLine
+  Set-Content -LiteralPath (Join-Path $AppDir "ema-runtime.cmd") -Value $RuntimeCmd -Encoding ASCII
 
   $CreateShortcut = Read-Host "Create desktop shortcut? [Y/n]"
   if ([string]::IsNullOrWhiteSpace($CreateShortcut) -or $CreateShortcut -match "^(y|yes)$") {

--- a/packages/ema-dist/src/installer.ts
+++ b/packages/ema-dist/src/installer.ts
@@ -173,79 +173,114 @@ function windowsInstaller(
   archive: Buffer,
   sevenZip: Buffer,
 ): string {
-  return `$ErrorActionPreference = "Stop"
-$Platform = "${platform.id}"
-$Kind = "${kind}"
-$SevenZipBase64 = @'
+  return `@echo off
+setlocal EnableExtensions
+set "PLATFORM=${platform.id}"
+set "KIND=${kind}"
+set "TMP_DIR=%TEMP%\\ema-installer-%RANDOM%%RANDOM%%RANDOM%"
+set "EXIT_CODE=0"
+
+mkdir "%TMP_DIR%" >nul 2>nul
+if errorlevel 1 (
+  echo Failed to create temporary directory: "%TMP_DIR%"
+  exit /b 1
+)
+
+set "SEVENZIP_B64=%TMP_DIR%\\7za.b64"
+set "ARCHIVE_B64=%TMP_DIR%\\payload.b64"
+set "SEVENZIP_PATH=%TMP_DIR%\\7za.exe"
+set "ARCHIVE_PATH=%TMP_DIR%\\payload.7z"
+
+call :extract_section EMA_SEVENZIP "%SEVENZIP_B64%" || goto fail
+call :decode_base64 "%SEVENZIP_B64%" "%SEVENZIP_PATH%" || goto fail
+call :extract_section EMA_ARCHIVE "%ARCHIVE_B64%" || goto fail
+call :decode_base64 "%ARCHIVE_B64%" "%ARCHIVE_PATH%" || goto fail
+
+set "DEFAULT_PARENT=%USERPROFILE%"
+set /p INSTALL_PARENT=Install parent directory [%DEFAULT_PARENT%]: 
+if not defined INSTALL_PARENT set "INSTALL_PARENT=%DEFAULT_PARENT%"
+mkdir "%INSTALL_PARENT%" >nul 2>nul
+
+"%SEVENZIP_PATH%" x "%ARCHIVE_PATH%" "-o%INSTALL_PARENT%" -y
+if errorlevel 1 goto fail
+
+set "APP_DIR=%INSTALL_PARENT%\\EverMemoryArchive"
+set "NODE_PATH_INPUT="
+set "MONGO_PATH_INPUT="
+set "MONGO_URI_INPUT="
+if /I "%KIND%"=="minimal" (
+  set /p NODE_PATH_INPUT=Node executable path [PATH]: 
+  set /p MONGO_PATH_INPUT=mongod executable path [PATH]: 
+  set /p MONGO_URI_INPUT=MongoDB URI [start local mongod]: 
+)
+
+set "OPEN_MODE=webview"
+set /p USE_BROWSER=Use default browser instead of app/webview window? [y/N]: 
+if /I "%USE_BROWSER%"=="y" set "OPEN_MODE=browser"
+if /I "%USE_BROWSER%"=="yes" set "OPEN_MODE=browser"
+
+> "%APP_DIR%\\ema-runtime.cmd" echo set "EMA_NODE_PATH=%NODE_PATH_INPUT%"
+>> "%APP_DIR%\\ema-runtime.cmd" echo set "EMA_MONGO_PATH=%MONGO_PATH_INPUT%"
+>> "%APP_DIR%\\ema-runtime.cmd" echo set "EMA_MONGO_URI=%MONGO_URI_INPUT%"
+>> "%APP_DIR%\\ema-runtime.cmd" echo set "EMA_HOST=127.0.0.1"
+>> "%APP_DIR%\\ema-runtime.cmd" echo set "EMA_PORT=3000"
+>> "%APP_DIR%\\ema-runtime.cmd" echo set "EMA_OPEN_MODE=%OPEN_MODE%"
+
+set /p CREATE_SHORTCUT=Create desktop shortcut? [Y/n]: 
+if not defined CREATE_SHORTCUT set "CREATE_SHORTCUT=Y"
+if /I "%CREATE_SHORTCUT%"=="y" call :create_shortcut
+if /I "%CREATE_SHORTCUT%"=="yes" call :create_shortcut
+
+echo Installed EverMemoryArchive to "%APP_DIR%"
+echo Run "%APP_DIR%\\start.cmd" to start.
+goto cleanup
+
+:fail
+set "EXIT_CODE=1"
+echo Installation failed.
+goto cleanup
+
+:cleanup
+if exist "%TMP_DIR%" rd /s /q "%TMP_DIR%" >nul 2>nul
+exit /b %EXIT_CODE%
+
+:decode_base64
+certutil -f -decode "%~1" "%~2" >nul 2>nul
+if errorlevel 1 (
+  echo Failed to decode "%~1". certutil.exe is required on Windows.
+  exit /b 1
+)
+exit /b 0
+
+:extract_section
+set "SECTION=%~1"
+set "OUT_FILE=%~2"
+set "INSIDE="
+> "%OUT_FILE%" (
+  for /f "usebackq delims=" %%L in ("%~f0") do (
+    if "%%L"=="__%SECTION%_END__" set "INSIDE="
+    if defined INSIDE echo(%%L
+    if "%%L"=="__%SECTION%_BEGIN__" set "INSIDE=1"
+  )
+)
+exit /b 0
+
+:create_shortcut
+set "DESKTOP=%USERPROFILE%\\Desktop"
+if not exist "%DESKTOP%" exit /b 0
+set "SHORTCUT=%DESKTOP%\\EverMemoryArchive.cmd"
+> "%SHORTCUT%" echo @echo off
+>> "%SHORTCUT%" echo cd /d "%APP_DIR%"
+>> "%SHORTCUT%" echo call "%APP_DIR%\\start.cmd"
+echo Created "%SHORTCUT%"
+exit /b 0
+
+__EMA_SEVENZIP_BEGIN__
 ${wrapBase64(sevenZip)}
-'@
-$ArchiveBase64 = @'
+__EMA_SEVENZIP_END__
+__EMA_ARCHIVE_BEGIN__
 ${wrapBase64(archive)}
-'@
-
-$TempDir = Join-Path $env:TEMP ("ema-installer-" + [guid]::NewGuid().ToString("N"))
-New-Item -ItemType Directory -Force -Path $TempDir | Out-Null
-try {
-  $SevenZipPath = Join-Path $TempDir "7za.exe"
-  $ArchivePath = Join-Path $TempDir "payload.7z"
-  [IO.File]::WriteAllBytes($SevenZipPath, [Convert]::FromBase64String(($SevenZipBase64 -replace "\\s", "")))
-  [IO.File]::WriteAllBytes($ArchivePath, [Convert]::FromBase64String(($ArchiveBase64 -replace "\\s", "")))
-
-  $DefaultParent = $env:USERPROFILE
-  $InstallParent = Read-Host "Install parent directory [$DefaultParent]"
-  if ([string]::IsNullOrWhiteSpace($InstallParent)) {
-    $InstallParent = $DefaultParent
-  }
-  New-Item -ItemType Directory -Force -Path $InstallParent | Out-Null
-
-  & $SevenZipPath x $ArchivePath "-o$InstallParent" -y
-  if ($LASTEXITCODE -ne 0) {
-    exit $LASTEXITCODE
-  }
-
-  $AppDir = Join-Path $InstallParent "EverMemoryArchive"
-  $NodePath = ""
-  $MongoPath = ""
-  $MongoUri = ""
-  if ($Kind -eq "minimal") {
-    $NodePath = Read-Host "Node executable path [PATH]"
-    $MongoPath = Read-Host "mongod executable path [PATH]"
-    $MongoUri = Read-Host "MongoDB URI [start local mongod]"
-  }
-
-  $UseBrowser = Read-Host "Use default browser instead of app/webview window? [y/N]"
-  $OpenMode = "webview"
-  if ($UseBrowser -match "^(y|yes)$") {
-    $OpenMode = "browser"
-  }
-
-  $RuntimeCmd = @(
-    'set "EMA_NODE_PATH=' + ($NodePath -replace '"', '') + '"',
-    'set "EMA_MONGO_PATH=' + ($MongoPath -replace '"', '') + '"',
-    'set "EMA_MONGO_URI=' + ($MongoUri -replace '"', '') + '"',
-    'set "EMA_HOST=127.0.0.1"',
-    'set "EMA_PORT=3000"',
-    'set "EMA_OPEN_MODE=' + $OpenMode + '"'
-  ) -join [Environment]::NewLine
-  Set-Content -LiteralPath (Join-Path $AppDir "ema-runtime.cmd") -Value $RuntimeCmd -Encoding ASCII
-
-  $CreateShortcut = Read-Host "Create desktop shortcut? [Y/n]"
-  if ([string]::IsNullOrWhiteSpace($CreateShortcut) -or $CreateShortcut -match "^(y|yes)$") {
-    $Desktop = [Environment]::GetFolderPath("Desktop")
-    $ShortcutPath = Join-Path $Desktop "EverMemoryArchive.lnk"
-    $Shell = New-Object -ComObject WScript.Shell
-    $Shortcut = $Shell.CreateShortcut($ShortcutPath)
-    $Shortcut.TargetPath = Join-Path $AppDir "start.cmd"
-    $Shortcut.WorkingDirectory = $AppDir
-    $Shortcut.Save()
-  }
-
-  Write-Host "Installed EverMemoryArchive to $AppDir"
-  $StartCmd = Join-Path $AppDir "start.cmd"
-  Write-Host "Run $StartCmd to start."
-} finally {
-  Remove-Item -LiteralPath $TempDir -Recurse -Force -ErrorAction SilentlyContinue
-}
+__EMA_ARCHIVE_END__
 `;
 }
 

--- a/packages/ema-dist/src/installer.ts
+++ b/packages/ema-dist/src/installer.ts
@@ -1,0 +1,232 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import {
+  installerFileName,
+  packageFileName,
+  platformDistRoot,
+  portableStageRoot,
+} from "./paths";
+import type { PackageKind, Platform } from "./platforms";
+
+export async function createSelfInstaller(
+  platform: Platform,
+  kind: PackageKind,
+  revision: string,
+): Promise<string> {
+  const outDir = platformDistRoot(platform);
+  const archivePath = path.join(
+    outDir,
+    packageFileName(platform, kind, revision, "7z"),
+  );
+  const sevenZipPath = installerSevenZipPath(platform);
+  const outputPath = path.join(
+    outDir,
+    installerFileName(platform, kind, revision),
+  );
+
+  const [archive, sevenZip] = await Promise.all([
+    fs.readFile(archivePath),
+    fs.readFile(sevenZipPath),
+  ]);
+  const script =
+    platform.os === "win32"
+      ? windowsInstaller(platform, kind, archive, sevenZip)
+      : posixInstaller(platform, kind, archive, sevenZip);
+  await fs.writeFile(outputPath, script, {
+    mode: platform.os === "win32" ? 0o644 : 0o755,
+  });
+  if (platform.os !== "win32") {
+    await fs.chmod(outputPath, 0o755);
+  }
+  return outputPath;
+}
+
+function installerSevenZipPath(platform: Platform): string {
+  const binary = platform.os === "win32" ? "7za.exe" : "7zz";
+  return path.join(portableStageRoot(platform), "portables", "7zip", binary);
+}
+
+function posixInstaller(
+  platform: Platform,
+  kind: PackageKind,
+  archive: Buffer,
+  sevenZip: Buffer,
+): string {
+  return `#!/usr/bin/env bash
+set -euo pipefail
+
+PLATFORM="${platform.id}"
+KIND="${kind}"
+TMP_DIR="$(mktemp -d)"
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT INT TERM
+
+extract_section() {
+  awk "/^__EMA_$1_BEGIN__$/ {flag=1; next} /^__EMA_$1_END__$/ {flag=0} flag {print}" "$0"
+}
+
+decode_section() {
+  if base64 --help 2>/dev/null | grep -q -- "--decode"; then
+    extract_section "$1" | base64 --decode > "$2"
+  else
+    extract_section "$1" | base64 -D > "$2"
+  fi
+}
+
+SEVENZIP="$TMP_DIR/7zz"
+ARCHIVE="$TMP_DIR/payload.7z"
+decode_section SEVENZIP "$SEVENZIP"
+decode_section ARCHIVE "$ARCHIVE"
+chmod +x "$SEVENZIP"
+
+DEFAULT_PARENT="\${HOME:-.}"
+printf "Install parent directory [%s]: " "$DEFAULT_PARENT"
+read -r INSTALL_PARENT
+INSTALL_PARENT="\${INSTALL_PARENT:-$DEFAULT_PARENT}"
+mkdir -p "$INSTALL_PARENT"
+
+"$SEVENZIP" x "$ARCHIVE" "-o$INSTALL_PARENT" -y
+APP_DIR="$INSTALL_PARENT/EverMemoryArchive"
+chmod +x "$APP_DIR/start.sh" "$APP_DIR/configure.sh" 2>/dev/null || true
+
+if [ "$KIND" = "minimal" ]; then
+  printf "Node executable path [PATH]: "
+  read -r NODE_PATH_INPUT
+  printf "mongod executable path [PATH]: "
+  read -r MONGO_PATH_INPUT
+  printf "MongoDB URI [start local mongod]: "
+  read -r MONGO_URI_INPUT
+  cat > "$APP_DIR/ema-runtime.sh" <<EOF
+export EMA_NODE_PATH="$NODE_PATH_INPUT"
+export EMA_MONGO_PATH="$MONGO_PATH_INPUT"
+export EMA_MONGO_URI="$MONGO_URI_INPUT"
+export EMA_HOST="127.0.0.1"
+export EMA_PORT="3000"
+EOF
+fi
+
+printf "Create shortcut? [Y/n]: "
+read -r CREATE_SHORTCUT
+CREATE_SHORTCUT="\${CREATE_SHORTCUT:-Y}"
+case "$CREATE_SHORTCUT" in
+  y|Y|yes|YES)
+    if [ "$PLATFORM" = "darwin-x64" ] || [ "$PLATFORM" = "darwin-arm64" ]; then
+      SHORTCUT="$HOME/Desktop/EverMemoryArchive.command"
+      cat > "$SHORTCUT" <<EOF
+#!/usr/bin/env bash
+cd "$APP_DIR"
+exec ./start.sh
+EOF
+      chmod +x "$SHORTCUT"
+    else
+      mkdir -p "$HOME/.local/share/applications"
+      DESKTOP_FILE="$HOME/.local/share/applications/evermemoryarchive.desktop"
+      cat > "$DESKTOP_FILE" <<EOF
+[Desktop Entry]
+Type=Application
+Name=EverMemoryArchive
+Exec=$APP_DIR/start.sh
+Path=$APP_DIR
+Terminal=true
+Categories=Utility;
+EOF
+      if [ -d "$HOME/Desktop" ]; then
+        cp "$DESKTOP_FILE" "$HOME/Desktop/EverMemoryArchive.desktop"
+        chmod +x "$HOME/Desktop/EverMemoryArchive.desktop"
+      fi
+    fi
+    ;;
+esac
+
+echo "Installed EverMemoryArchive to $APP_DIR"
+echo "Run $APP_DIR/start.sh to start."
+exit 0
+
+__EMA_SEVENZIP_BEGIN__
+${wrapBase64(sevenZip)}
+__EMA_SEVENZIP_END__
+__EMA_ARCHIVE_BEGIN__
+${wrapBase64(archive)}
+__EMA_ARCHIVE_END__
+`;
+}
+
+function windowsInstaller(
+  platform: Platform,
+  kind: PackageKind,
+  archive: Buffer,
+  sevenZip: Buffer,
+): string {
+  return `$ErrorActionPreference = "Stop"
+$Platform = "${platform.id}"
+$Kind = "${kind}"
+$SevenZipBase64 = @'
+${wrapBase64(sevenZip)}
+'@
+$ArchiveBase64 = @'
+${wrapBase64(archive)}
+'@
+
+$TempDir = Join-Path $env:TEMP ("ema-installer-" + [guid]::NewGuid().ToString("N"))
+New-Item -ItemType Directory -Force -Path $TempDir | Out-Null
+try {
+  $SevenZipPath = Join-Path $TempDir "7za.exe"
+  $ArchivePath = Join-Path $TempDir "payload.7z"
+  [IO.File]::WriteAllBytes($SevenZipPath, [Convert]::FromBase64String(($SevenZipBase64 -replace "\\s", "")))
+  [IO.File]::WriteAllBytes($ArchivePath, [Convert]::FromBase64String(($ArchiveBase64 -replace "\\s", "")))
+
+  $DefaultParent = $env:USERPROFILE
+  $InstallParent = Read-Host "Install parent directory [$DefaultParent]"
+  if ([string]::IsNullOrWhiteSpace($InstallParent)) {
+    $InstallParent = $DefaultParent
+  }
+  New-Item -ItemType Directory -Force -Path $InstallParent | Out-Null
+
+  & $SevenZipPath x $ArchivePath "-o$InstallParent" -y
+  if ($LASTEXITCODE -ne 0) {
+    exit $LASTEXITCODE
+  }
+
+  $AppDir = Join-Path $InstallParent "EverMemoryArchive"
+  if ($Kind -eq "minimal") {
+    $NodePath = Read-Host "Node executable path [PATH]"
+    $MongoPath = Read-Host "mongod executable path [PATH]"
+    $MongoUri = Read-Host "MongoDB URI [start local mongod]"
+    $RuntimeCmd = @(
+      'set "EMA_NODE_PATH=' + ($NodePath -replace '"', '') + '"',
+      'set "EMA_MONGO_PATH=' + ($MongoPath -replace '"', '') + '"',
+      'set "EMA_MONGO_URI=' + ($MongoUri -replace '"', '') + '"',
+      'set "EMA_HOST=127.0.0.1"',
+      'set "EMA_PORT=3000"'
+    ) -join [Environment]::NewLine
+    Set-Content -LiteralPath (Join-Path $AppDir "ema-runtime.cmd") -Value $RuntimeCmd -Encoding ASCII
+  }
+
+  $CreateShortcut = Read-Host "Create desktop shortcut? [Y/n]"
+  if ([string]::IsNullOrWhiteSpace($CreateShortcut) -or $CreateShortcut -match "^(y|yes)$") {
+    $Desktop = [Environment]::GetFolderPath("Desktop")
+    $ShortcutPath = Join-Path $Desktop "EverMemoryArchive.lnk"
+    $Shell = New-Object -ComObject WScript.Shell
+    $Shortcut = $Shell.CreateShortcut($ShortcutPath)
+    $Shortcut.TargetPath = Join-Path $AppDir "start.cmd"
+    $Shortcut.WorkingDirectory = $AppDir
+    $Shortcut.Save()
+  }
+
+  Write-Host "Installed EverMemoryArchive to $AppDir"
+  $StartCmd = Join-Path $AppDir "start.cmd"
+  Write-Host "Run $StartCmd to start."
+} finally {
+  Remove-Item -LiteralPath $TempDir -Recurse -Force -ErrorAction SilentlyContinue
+}
+`;
+}
+
+function wrapBase64(value: Buffer): string {
+  return value
+    .toString("base64")
+    .replace(/.{1,76}/gu, (chunk) => `${chunk}\n`)
+    .trimEnd();
+}

--- a/packages/ema-dist/src/paths.ts
+++ b/packages/ema-dist/src/paths.ts
@@ -1,0 +1,59 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { PackageKind, Platform } from "./platforms";
+
+export function workspaceRoot(): string {
+  return path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "..",
+    "..",
+    "..",
+  );
+}
+
+export function distRoot(): string {
+  return path.join(workspaceRoot(), "dist");
+}
+
+export function platformDistRoot(platform: Platform): string {
+  return path.join(distRoot(), platform.id);
+}
+
+export function portableStageRoot(platform: Platform): string {
+  return path.join(platformDistRoot(platform), "EverMemoryArchive");
+}
+
+export function minimalStageRoot(platform: Platform): string {
+  return path.join(platformDistRoot(platform), ".minimal", "EverMemoryArchive");
+}
+
+export function stageRoot(platform: Platform, kind: PackageKind): string {
+  return kind === "portable"
+    ? portableStageRoot(platform)
+    : minimalStageRoot(platform);
+}
+
+export function downloadsRoot(): string {
+  return path.join(distRoot(), ".downloads");
+}
+
+export function packageFileName(
+  platform: Platform,
+  kind: PackageKind,
+  revision: string,
+  extension: "7z" | "zip",
+): string {
+  return `ema-${platform.id}-${kind}-${revision}.${extension}`;
+}
+
+export function installerFileName(
+  platform: Platform,
+  kind: PackageKind,
+  revision: string,
+): string {
+  return `ema-${platform.id}-${kind}-${revision}-installer${platform.installerExt}`;
+}
+
+export function toPosixPath(value: string): string {
+  return value.split(path.sep).join("/");
+}

--- a/packages/ema-dist/src/platforms.ts
+++ b/packages/ema-dist/src/platforms.ts
@@ -13,7 +13,7 @@ export interface Platform {
   readonly label: string;
   readonly os: "win32" | "linux" | "darwin" | "alpine";
   readonly arch: "x64" | "arm64" | "armhf";
-  readonly installerExt: ".ps1" | ".run" | ".command";
+  readonly installerExt: ".bat" | ".run" | ".command";
   readonly executableExt: "" | ".exe";
   readonly canBundleMongo: boolean;
   readonly mongoNote?: string;
@@ -23,14 +23,14 @@ const PLATFORM_DETAILS: Record<PlatformId, Omit<Platform, "id" | "label">> = {
   "win32-x64": {
     os: "win32",
     arch: "x64",
-    installerExt: ".ps1",
+    installerExt: ".bat",
     executableExt: ".exe",
     canBundleMongo: true,
   },
   "win32-arm64": {
     os: "win32",
     arch: "arm64",
-    installerExt: ".ps1",
+    installerExt: ".bat",
     executableExt: ".exe",
     canBundleMongo: true,
     mongoNote:

--- a/packages/ema-dist/src/platforms.ts
+++ b/packages/ema-dist/src/platforms.ts
@@ -1,0 +1,154 @@
+export type PlatformId =
+  | "win32-x64"
+  | "win32-arm64"
+  | "linux-x64"
+  | "linux-arm64"
+  | "linux-armhf"
+  | "darwin-x64"
+  | "darwin-arm64"
+  | "alpine-x64";
+
+export interface Platform {
+  readonly id: PlatformId;
+  readonly label: string;
+  readonly os: "win32" | "linux" | "darwin" | "alpine";
+  readonly arch: "x64" | "arm64" | "armhf";
+  readonly installerExt: ".ps1" | ".run" | ".command";
+  readonly executableExt: "" | ".exe";
+  readonly canBundleMongo: boolean;
+  readonly mongoNote?: string;
+}
+
+const PLATFORM_DETAILS: Record<PlatformId, Omit<Platform, "id" | "label">> = {
+  "win32-x64": {
+    os: "win32",
+    arch: "x64",
+    installerExt: ".ps1",
+    executableExt: ".exe",
+    canBundleMongo: true,
+  },
+  "win32-arm64": {
+    os: "win32",
+    arch: "arm64",
+    installerExt: ".ps1",
+    executableExt: ".exe",
+    canBundleMongo: true,
+    mongoNote:
+      "MongoDB does not publish native Windows ARM64 community archives; the x64 archive is bundled for Windows-on-ARM emulation.",
+  },
+  "linux-x64": {
+    os: "linux",
+    arch: "x64",
+    installerExt: ".run",
+    executableExt: "",
+    canBundleMongo: true,
+  },
+  "linux-arm64": {
+    os: "linux",
+    arch: "arm64",
+    installerExt: ".run",
+    executableExt: "",
+    canBundleMongo: true,
+  },
+  "linux-armhf": {
+    os: "linux",
+    arch: "armhf",
+    installerExt: ".run",
+    executableExt: "",
+    canBundleMongo: false,
+    mongoNote:
+      "MongoDB Community Server does not publish ARMv7/armhf archives.",
+  },
+  "darwin-x64": {
+    os: "darwin",
+    arch: "x64",
+    installerExt: ".command",
+    executableExt: "",
+    canBundleMongo: true,
+  },
+  "darwin-arm64": {
+    os: "darwin",
+    arch: "arm64",
+    installerExt: ".command",
+    executableExt: "",
+    canBundleMongo: true,
+  },
+  "alpine-x64": {
+    os: "alpine",
+    arch: "x64",
+    installerExt: ".run",
+    executableExt: "",
+    canBundleMongo: false,
+    mongoNote:
+      "MongoDB Community Server does not publish Alpine/musl archives.",
+  },
+};
+
+function platform(id: PlatformId, label: string): Platform {
+  return {
+    id,
+    label,
+    ...PLATFORM_DETAILS[id],
+  };
+}
+
+export const PLATFORMS = [
+  platform("win32-x64", "x64 Windows"),
+  platform("win32-arm64", "ARM64 Windows"),
+  platform("linux-x64", "x64 Linux"),
+  platform("linux-arm64", "ARM64 Linux"),
+  platform("linux-armhf", "ARMv7 Linux"),
+  platform("darwin-x64", "Intel macOS"),
+  platform("darwin-arm64", "Apple Silicon macOS"),
+  platform("alpine-x64", "x64 Alpine Linux"),
+] as const;
+
+export const PLATFORM_IDS = PLATFORMS.map((item) => item.id);
+
+export function getPlatform(id: string): Platform {
+  const platform = PLATFORMS.find((item) => item.id === id);
+  if (!platform) {
+    throw new Error(
+      `Unsupported platform '${id}'. Expected one of: ${PLATFORM_IDS.join(
+        ", ",
+      )}.`,
+    );
+  }
+  return platform;
+}
+
+export function hostPlatformId(): PlatformId {
+  const os = process.platform;
+  const arch = process.arch;
+  if (os === "win32" && arch === "x64") {
+    return "win32-x64";
+  }
+  if (os === "win32" && arch === "arm64") {
+    return "win32-arm64";
+  }
+  if (os === "darwin" && arch === "x64") {
+    return "darwin-x64";
+  }
+  if (os === "darwin" && arch === "arm64") {
+    return "darwin-arm64";
+  }
+  if (os === "linux" && arch === "x64") {
+    return "linux-x64";
+  }
+  if (os === "linux" && arch === "arm64") {
+    return "linux-arm64";
+  }
+  if (os === "linux" && (arch === "arm" || arch === "arm64")) {
+    return "linux-armhf";
+  }
+  throw new Error(`Cannot map host platform '${os}-${arch}' to EMA platform.`);
+}
+
+export type PackageKind = "portable" | "minimal";
+
+export function assertPackageKind(value: string): PackageKind {
+  if (value === "portable" || value === "minimal") {
+    return value;
+  }
+  throw new Error(`Unsupported package kind '${value}'.`);
+}

--- a/packages/ema-dist/src/raw-import-hooks.mjs
+++ b/packages/ema-dist/src/raw-import-hooks.mjs
@@ -1,0 +1,35 @@
+import fs from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+
+const RAW_QUERY = "?raw";
+
+export async function resolve(specifier, context, nextResolve) {
+  if (!specifier.endsWith(RAW_QUERY)) {
+    return nextResolve(specifier, context);
+  }
+
+  const resolved = await nextResolve(
+    specifier.slice(0, -RAW_QUERY.length),
+    context,
+  );
+  return {
+    shortCircuit: true,
+    url: `${resolved.url}${RAW_QUERY}`,
+  };
+}
+
+export async function load(url, context, nextLoad) {
+  if (!url.endsWith(RAW_QUERY)) {
+    return nextLoad(url, context);
+  }
+
+  const source = await fs.readFile(
+    fileURLToPath(url.slice(0, -RAW_QUERY.length)),
+    "utf8",
+  );
+  return {
+    format: "module",
+    shortCircuit: true,
+    source: `export default ${JSON.stringify(source)};`,
+  };
+}

--- a/packages/ema-dist/src/raw-import-loader.mjs
+++ b/packages/ema-dist/src/raw-import-loader.mjs
@@ -1,0 +1,3 @@
+import { register } from "node:module";
+
+register("./raw-import-hooks.mjs", import.meta.url);

--- a/packages/ema-dist/src/raw-imports.d.ts
+++ b/packages/ema-dist/src/raw-imports.d.ts
@@ -1,0 +1,4 @@
+declare module "*?raw" {
+  const source: string;
+  export default source;
+}

--- a/packages/ema-dist/src/revision.ts
+++ b/packages/ema-dist/src/revision.ts
@@ -1,0 +1,30 @@
+import { capture, execFile } from "./shell";
+import { workspaceRoot } from "./paths";
+
+export async function resolveRevision(): Promise<string> {
+  const cwd = workspaceRoot();
+  const tagResult = await execFile(
+    "git",
+    ["describe", "--tags", "--match", "v[0-9]*", "--abbrev=0", "HEAD"],
+    { cwd, quiet: true, allowFailure: true },
+  );
+  const baseTag = tagResult.code === 0 ? tagResult.stdout.trim() : "v0.0.0";
+  const hash = await capture("git", ["rev-parse", "--short=12", "HEAD"], {
+    cwd,
+  });
+  const exactTagResult = await execFile(
+    "git",
+    ["describe", "--exact-match", "--tags", "--match", "v[0-9]*", "HEAD"],
+    { cwd, quiet: true, allowFailure: true },
+  );
+  const dirty = (
+    await capture("git", ["status", "--short"], {
+      cwd,
+    })
+  ).length;
+
+  if (exactTagResult.code === 0 && exactTagResult.stdout.trim() === baseTag) {
+    return dirty ? `${baseTag}-${hash}-dirty` : baseTag;
+  }
+  return dirty ? `${baseTag}-${hash}-dirty` : `${baseTag}-${hash}`;
+}

--- a/packages/ema-dist/src/shell.ts
+++ b/packages/ema-dist/src/shell.ts
@@ -1,0 +1,86 @@
+import { spawn } from "node:child_process";
+
+export interface ExecOptions {
+  readonly cwd?: string;
+  readonly env?: NodeJS.ProcessEnv;
+  readonly quiet?: boolean;
+  readonly allowFailure?: boolean;
+}
+
+export interface ExecResult {
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly code: number;
+}
+
+export async function execFile(
+  command: string,
+  args: readonly string[],
+  options: ExecOptions = {},
+): Promise<ExecResult> {
+  return await new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: options.cwd,
+      env: options.env,
+      shell: false,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const stdout: Buffer[] = [];
+    const stderr: Buffer[] = [];
+
+    child.stdout.on("data", (chunk: Buffer) => {
+      stdout.push(chunk);
+      if (!options.quiet) {
+        process.stdout.write(chunk);
+      }
+    });
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderr.push(chunk);
+      if (!options.quiet) {
+        process.stderr.write(chunk);
+      }
+    });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      const result = {
+        stdout: Buffer.concat(stdout).toString("utf8"),
+        stderr: Buffer.concat(stderr).toString("utf8"),
+        code: code ?? 0,
+      };
+      if (result.code !== 0 && !options.allowFailure) {
+        reject(
+          new Error(
+            `${command} ${args.join(" ")} failed with exit code ${
+              result.code
+            }\n${result.stderr}`,
+          ),
+        );
+        return;
+      }
+      resolve(result);
+    });
+  });
+}
+
+export async function capture(
+  command: string,
+  args: readonly string[],
+  options: Omit<ExecOptions, "quiet"> = {},
+): Promise<string> {
+  const result = await execFile(command, args, { ...options, quiet: true });
+  return result.stdout.trim();
+}
+
+export async function commandExists(command: string): Promise<boolean> {
+  const probe =
+    process.platform === "win32"
+      ? await execFile("where", [command], {
+          quiet: true,
+          allowFailure: true,
+        })
+      : await execFile("which", [command], {
+          quiet: true,
+          allowFailure: true,
+        });
+  return probe.code === 0;
+}

--- a/packages/ema-dist/src/stage.ts
+++ b/packages/ema-dist/src/stage.ts
@@ -1,0 +1,480 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import {
+  minimalStageRoot,
+  portableStageRoot,
+  stageRoot,
+  toPosixPath,
+  workspaceRoot,
+} from "./paths";
+import type { PackageKind, Platform } from "./platforms";
+
+interface StageOptions {
+  readonly platform: Platform;
+  readonly kind: PackageKind;
+  readonly revision: string;
+}
+
+interface AppStageResult {
+  readonly root: string;
+  readonly serverRelativePath: string;
+}
+
+export async function stagePackage(options: StageOptions): Promise<string> {
+  const root = stageRoot(options.platform, options.kind);
+  await fs.rm(root, { recursive: true, force: true });
+  await fs.mkdir(root, { recursive: true });
+  const app = await copyStandaloneApp(root);
+  await copyIfExists(
+    path.join(workspaceRoot(), "README.md"),
+    path.join(root, "README.md"),
+  );
+  await copyIfExists(
+    path.join(workspaceRoot(), "LICENSE"),
+    path.join(root, "LICENSE"),
+  );
+  await writeLaunchers(
+    root,
+    options.platform,
+    options.kind,
+    app.serverRelativePath,
+  );
+  await writePackageManifest(root, options, app.serverRelativePath);
+  return root;
+}
+
+export async function refreshMinimalStageFromPortable(
+  platform: Platform,
+  revision: string,
+): Promise<string> {
+  const source = portableStageRoot(platform);
+  const target = minimalStageRoot(platform);
+  await fs.rm(target, { recursive: true, force: true });
+  await copyDirectoryWithout(source, target, new Set(["portables"]));
+  await writePackageManifest(
+    target,
+    {
+      platform,
+      kind: "minimal",
+      revision,
+    },
+    await readServerRelativePath(target),
+  );
+  return target;
+}
+
+async function copyStandaloneApp(root: string): Promise<AppStageResult> {
+  const workspace = workspaceRoot();
+  const webuiRoot = path.join(workspace, "packages", "ema-webui");
+  const standaloneRoot = path.join(webuiRoot, ".next", "standalone");
+  const staticRoot = path.join(webuiRoot, ".next", "static");
+  const publicRoot = path.join(webuiRoot, "public");
+
+  if (!(await exists(standaloneRoot))) {
+    throw new Error(
+      "Next.js standalone output was not found. Run pnpm --filter ema-webui build first.",
+    );
+  }
+
+  const appRoot = path.join(root, "app");
+  await fs.cp(standaloneRoot, appRoot, {
+    recursive: true,
+    force: true,
+    preserveTimestamps: true,
+  });
+
+  const serverPath = await findServerEntry(appRoot);
+  const serverDir = path.dirname(serverPath);
+  await copyIfExists(staticRoot, path.join(serverDir, ".next", "static"));
+  await copyIfExists(publicRoot, path.join(serverDir, "public"));
+  await copyEmaRuntimeAssets(appRoot);
+
+  const serverRelativePath = toPosixPath(path.relative(root, serverPath));
+  await fs.writeFile(
+    path.join(root, "server-relpath.txt"),
+    `${serverRelativePath}\n`,
+  );
+  return { root: appRoot, serverRelativePath };
+}
+
+async function findServerEntry(appRoot: string): Promise<string> {
+  const preferred = [
+    path.join(appRoot, "packages", "ema-webui", "server.js"),
+    path.join(appRoot, "server.js"),
+  ];
+  for (const candidate of preferred) {
+    if (await exists(candidate)) {
+      return candidate;
+    }
+  }
+  const found = await findFile(
+    appRoot,
+    (filePath) => path.basename(filePath) === "server.js",
+  );
+  if (!found) {
+    throw new Error(
+      `Could not find Next.js standalone server.js in ${appRoot}.`,
+    );
+  }
+  return found;
+}
+
+async function copyEmaRuntimeAssets(appRoot: string): Promise<void> {
+  const sourceRoot = path.join(workspaceRoot(), "packages", "ema", "src");
+  const candidates = [
+    path.join(appRoot, "packages", "ema", "src"),
+    path.join(appRoot, "node_modules", "ema", "src"),
+  ];
+  for (const candidate of candidates) {
+    await copyIfExists(
+      path.join(sourceRoot, "prompt", "templates"),
+      path.join(candidate, "prompt", "templates"),
+    );
+    await copySkillAssets(
+      path.join(sourceRoot, "skills"),
+      path.join(candidate, "skills"),
+    );
+  }
+}
+
+async function copySkillAssets(
+  source: string,
+  destination: string,
+): Promise<void> {
+  if (!(await exists(source))) {
+    return;
+  }
+  const entries = await fs.readdir(source, { withFileTypes: true });
+  for (const entry of entries) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+    const from = path.join(source, entry.name);
+    const to = path.join(destination, entry.name);
+    await copyIfExists(path.join(from, "SKILL.md"), path.join(to, "SKILL.md"));
+    await copyIfExists(path.join(from, "assets"), path.join(to, "assets"));
+  }
+}
+
+async function writeLaunchers(
+  root: string,
+  platform: Platform,
+  kind: PackageKind,
+  serverRelativePath: string,
+): Promise<void> {
+  await fs.writeFile(
+    path.join(root, "start.sh"),
+    posixStartScript(serverRelativePath),
+    {
+      mode: 0o755,
+    },
+  );
+  await fs.writeFile(path.join(root, "configure.sh"), posixConfigureScript(), {
+    mode: 0o755,
+  });
+  await fs.writeFile(
+    path.join(root, "start.cmd"),
+    windowsStartScript(serverRelativePath),
+  );
+  await fs.writeFile(
+    path.join(root, "configure.cmd"),
+    windowsConfigureScript(),
+  );
+  if (platform.os !== "win32") {
+    await fs.chmod(path.join(root, "start.sh"), 0o755);
+    await fs.chmod(path.join(root, "configure.sh"), 0o755);
+  }
+  await fs.writeFile(
+    path.join(root, "INSTALL.txt"),
+    installText(platform, kind),
+  );
+}
+
+async function writePackageManifest(
+  root: string,
+  options: StageOptions,
+  serverRelativePath: string,
+): Promise<void> {
+  await fs.writeFile(
+    path.join(root, "ema-package.json"),
+    `${JSON.stringify(
+      {
+        name: "EverMemoryArchive",
+        revision: options.revision,
+        platform: options.platform.id,
+        platformLabel: options.platform.label,
+        kind: options.kind,
+        serverRelativePath,
+        portableMongoBundled:
+          options.kind === "portable" && options.platform.canBundleMongo,
+        portableMongoNote: options.platform.mongoNote,
+        createdAt: new Date().toISOString(),
+      },
+      null,
+      2,
+    )}\n`,
+  );
+}
+
+async function readServerRelativePath(root: string): Promise<string> {
+  return (
+    await fs.readFile(path.join(root, "server-relpath.txt"), "utf8")
+  ).trim();
+}
+
+function posixStartScript(serverRelativePath: string): string {
+  return `#!/usr/bin/env bash
+set -euo pipefail
+
+APP_ROOT="$(cd "$(dirname "\${BASH_SOURCE[0]}")" && pwd)"
+if [ -f "$APP_ROOT/ema-runtime.sh" ]; then
+  # shellcheck disable=SC1091
+  . "$APP_ROOT/ema-runtime.sh"
+fi
+
+SERVER_JS="$APP_ROOT/${serverRelativePath}"
+DATA_ROOT="\${EMA_DATA_ROOT:-$APP_ROOT/.ema}"
+HOST="\${EMA_HOST:-127.0.0.1}"
+PORT="\${EMA_PORT:-3000}"
+MONGO_PORT="\${EMA_MONGO_PORT:-27017}"
+NODE_BIN="\${EMA_NODE_PATH:-}"
+MONGO_BIN="\${EMA_MONGO_PATH:-}"
+
+if [ -z "$NODE_BIN" ]; then
+  if [ -x "$APP_ROOT/portables/node/bin/node" ]; then
+    NODE_BIN="$APP_ROOT/portables/node/bin/node"
+  else
+    NODE_BIN="$(command -v node || true)"
+  fi
+fi
+
+if [ -z "$NODE_BIN" ]; then
+  echo "Node.js was not found. Run configure.sh or put node on PATH." >&2
+  exit 1
+fi
+
+mkdir -p "$DATA_ROOT/mongodb" "$DATA_ROOT/logs" "$DATA_ROOT/workspace"
+
+MONGO_URI="\${EMA_MONGO_URI:-}"
+MONGO_PID=""
+if [ -z "$MONGO_URI" ]; then
+  if [ -z "$MONGO_BIN" ]; then
+    if [ -x "$APP_ROOT/portables/mongodb/bin/mongod" ]; then
+      MONGO_BIN="$APP_ROOT/portables/mongodb/bin/mongod"
+    else
+      MONGO_BIN="$(command -v mongod || true)"
+    fi
+  fi
+  if [ -z "$MONGO_BIN" ]; then
+    echo "MongoDB was not found. Run configure.sh, set EMA_MONGO_URI, or put mongod on PATH." >&2
+    exit 1
+  fi
+  MONGO_URI="mongodb://127.0.0.1:$MONGO_PORT/"
+  "$MONGO_BIN" --dbpath "$DATA_ROOT/mongodb" --port "$MONGO_PORT" --bind_ip 127.0.0.1 --logpath "$DATA_ROOT/logs/mongodb.log" &
+  MONGO_PID="$!"
+fi
+
+cleanup() {
+  if [ -n "$MONGO_PID" ]; then
+    kill "$MONGO_PID" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT INT TERM
+
+export HOSTNAME="$HOST"
+export PORT="$PORT"
+export EMA_SERVER_MODE=prod
+export EMA_SERVER_MONGO_KIND=remote
+export EMA_SERVER_MONGO_URI="$MONGO_URI"
+export EMA_SERVER_MONGO_DB="\${EMA_MONGO_DB:-ema}"
+export EMA_SERVER_DATA_ROOT="$DATA_ROOT"
+
+echo "EverMemoryArchive is starting at http://$HOST:$PORT/"
+"$NODE_BIN" "$SERVER_JS"
+`;
+}
+
+function windowsStartScript(serverRelativePath: string): string {
+  const windowsServerPath = serverRelativePath.split("/").join("\\");
+  return `@echo off
+setlocal
+set "APP_ROOT=%~dp0"
+if exist "%APP_ROOT%ema-runtime.cmd" call "%APP_ROOT%ema-runtime.cmd"
+
+set "SERVER_JS=%APP_ROOT%${windowsServerPath}"
+if not defined EMA_DATA_ROOT set "EMA_DATA_ROOT=%APP_ROOT%.ema"
+if not defined EMA_HOST set "EMA_HOST=127.0.0.1"
+if not defined EMA_PORT set "EMA_PORT=3000"
+if not defined EMA_MONGO_PORT set "EMA_MONGO_PORT=27017"
+
+set "NODE_BIN=%EMA_NODE_PATH%"
+if not defined NODE_BIN if exist "%APP_ROOT%portables\\node\\node.exe" set "NODE_BIN=%APP_ROOT%portables\\node\\node.exe"
+if not defined NODE_BIN for %%I in (node.exe) do set "NODE_BIN=%%~$PATH:I"
+if not defined NODE_BIN (
+  echo Node.js was not found. Run configure.cmd or put node on PATH.
+  exit /b 1
+)
+
+if not exist "%EMA_DATA_ROOT%\\mongodb" mkdir "%EMA_DATA_ROOT%\\mongodb"
+if not exist "%EMA_DATA_ROOT%\\logs" mkdir "%EMA_DATA_ROOT%\\logs"
+if not exist "%EMA_DATA_ROOT%\\workspace" mkdir "%EMA_DATA_ROOT%\\workspace"
+
+if not defined EMA_MONGO_URI (
+  set "MONGO_BIN=%EMA_MONGO_PATH%"
+  if not defined MONGO_BIN if exist "%APP_ROOT%portables\\mongodb\\bin\\mongod.exe" set "MONGO_BIN=%APP_ROOT%portables\\mongodb\\bin\\mongod.exe"
+  if not defined MONGO_BIN for %%I in (mongod.exe) do set "MONGO_BIN=%%~$PATH:I"
+  if not defined MONGO_BIN (
+    echo MongoDB was not found. Run configure.cmd, set EMA_MONGO_URI, or put mongod on PATH.
+    exit /b 1
+  )
+  set "EMA_MONGO_URI=mongodb://127.0.0.1:%EMA_MONGO_PORT%/"
+  start "EMA MongoDB" /B "%MONGO_BIN%" --dbpath "%EMA_DATA_ROOT%\\mongodb" --port "%EMA_MONGO_PORT%" --bind_ip 127.0.0.1 --logpath "%EMA_DATA_ROOT%\\logs\\mongodb.log"
+)
+
+set "HOSTNAME=%EMA_HOST%"
+set "PORT=%EMA_PORT%"
+set "EMA_SERVER_MODE=prod"
+set "EMA_SERVER_MONGO_KIND=remote"
+set "EMA_SERVER_MONGO_DB=ema"
+set "EMA_SERVER_DATA_ROOT=%EMA_DATA_ROOT%"
+set "EMA_SERVER_MONGO_URI=%EMA_MONGO_URI%"
+
+echo EverMemoryArchive is starting at http://%EMA_HOST%:%EMA_PORT%/
+"%NODE_BIN%" "%SERVER_JS%"
+endlocal
+`;
+}
+
+function posixConfigureScript(): string {
+  return `#!/usr/bin/env bash
+set -euo pipefail
+
+APP_ROOT="$(cd "$(dirname "\${BASH_SOURCE[0]}")" && pwd)"
+read -r -p "Node executable path [PATH or portable]: " NODE_PATH_INPUT
+read -r -p "mongod executable path [PATH or portable]: " MONGO_PATH_INPUT
+read -r -p "MongoDB URI [start local mongod]: " MONGO_URI_INPUT
+read -r -p "WebUI host [127.0.0.1]: " HOST_INPUT
+read -r -p "WebUI port [3000]: " PORT_INPUT
+
+cat > "$APP_ROOT/ema-runtime.sh" <<EOF
+export EMA_NODE_PATH="$NODE_PATH_INPUT"
+export EMA_MONGO_PATH="$MONGO_PATH_INPUT"
+export EMA_MONGO_URI="$MONGO_URI_INPUT"
+export EMA_HOST="\${HOST_INPUT:-127.0.0.1}"
+export EMA_PORT="\${PORT_INPUT:-3000}"
+EOF
+
+echo "Wrote $APP_ROOT/ema-runtime.sh"
+`;
+}
+
+function windowsConfigureScript(): string {
+  return `@echo off
+setlocal
+set "APP_ROOT=%~dp0"
+set /p EMA_NODE_PATH=Node executable path [PATH or portable]: 
+set /p EMA_MONGO_PATH=mongod executable path [PATH or portable]: 
+set /p EMA_MONGO_URI=MongoDB URI [start local mongod]: 
+set /p EMA_HOST=WebUI host [127.0.0.1]: 
+set /p EMA_PORT=WebUI port [3000]: 
+if not defined EMA_HOST set "EMA_HOST=127.0.0.1"
+if not defined EMA_PORT set "EMA_PORT=3000"
+(
+  echo set "EMA_NODE_PATH=%EMA_NODE_PATH%"
+  echo set "EMA_MONGO_PATH=%EMA_MONGO_PATH%"
+  echo set "EMA_MONGO_URI=%EMA_MONGO_URI%"
+  echo set "EMA_HOST=%EMA_HOST%"
+  echo set "EMA_PORT=%EMA_PORT%"
+) > "%APP_ROOT%ema-runtime.cmd"
+echo Wrote %APP_ROOT%ema-runtime.cmd
+endlocal
+`;
+}
+
+function installText(platform: Platform, kind: PackageKind): string {
+  const launcher =
+    platform.os === "win32"
+      ? "start.cmd"
+      : platform.os === "darwin"
+        ? "start.sh"
+        : "start.sh";
+  return `EverMemoryArchive ${kind} package for ${platform.label}
+
+Run ${launcher} to start the WebUI.
+
+portable:
+  Bundles Node.js and MongoDB when the platform has upstream MongoDB binaries.
+
+minimal:
+  Run configure.sh/configure.cmd to set Node.js and MongoDB paths, or put node
+  and mongod on PATH. You may also set EMA_MONGO_URI to use an external MongoDB.
+`;
+}
+
+async function copyIfExists(
+  source: string,
+  destination: string,
+): Promise<void> {
+  if (!(await exists(source))) {
+    return;
+  }
+  await fs.mkdir(path.dirname(destination), { recursive: true });
+  await fs.cp(source, destination, {
+    recursive: true,
+    force: true,
+    preserveTimestamps: true,
+  });
+}
+
+async function copyDirectoryWithout(
+  source: string,
+  destination: string,
+  excludedNames: Set<string>,
+): Promise<void> {
+  await fs.mkdir(destination, { recursive: true });
+  const entries = await fs.readdir(source, { withFileTypes: true });
+  for (const entry of entries) {
+    if (excludedNames.has(entry.name)) {
+      continue;
+    }
+    await fs.cp(
+      path.join(source, entry.name),
+      path.join(destination, entry.name),
+      {
+        recursive: true,
+        force: true,
+        preserveTimestamps: true,
+      },
+    );
+  }
+}
+
+async function findFile(
+  root: string,
+  predicate: (filePath: string) => boolean,
+): Promise<string | null> {
+  const entries = await fs.readdir(root, { withFileTypes: true });
+  for (const entry of entries) {
+    const entryPath = path.join(root, entry.name);
+    if (entry.isDirectory()) {
+      const nested = await findFile(entryPath, predicate);
+      if (nested) {
+        return nested;
+      }
+      continue;
+    }
+    if (predicate(entryPath)) {
+      return entryPath;
+    }
+  }
+  return null;
+}
+
+async function exists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/ema-dist/src/stage.ts
+++ b/packages/ema-dist/src/stage.ts
@@ -169,6 +169,9 @@ async function writeLaunchers(
       mode: 0o755,
     },
   );
+  await fs.writeFile(path.join(root, "open-webui.sh"), posixOpenWebuiScript(), {
+    mode: 0o755,
+  });
   await fs.writeFile(path.join(root, "configure.sh"), posixConfigureScript(), {
     mode: 0o755,
   });
@@ -177,11 +180,16 @@ async function writeLaunchers(
     windowsStartScript(serverRelativePath),
   );
   await fs.writeFile(
+    path.join(root, "open-webui.ps1"),
+    windowsOpenWebuiScript(),
+  );
+  await fs.writeFile(
     path.join(root, "configure.cmd"),
     windowsConfigureScript(),
   );
   if (platform.os !== "win32") {
     await fs.chmod(path.join(root, "start.sh"), 0o755);
+    await fs.chmod(path.join(root, "open-webui.sh"), 0o755);
     await fs.chmod(path.join(root, "configure.sh"), 0o755);
   }
   await fs.writeFile(
@@ -237,6 +245,7 @@ DATA_ROOT="\${EMA_DATA_ROOT:-$APP_ROOT/.ema}"
 HOST="\${EMA_HOST:-127.0.0.1}"
 PORT="\${EMA_PORT:-3000}"
 MONGO_PORT="\${EMA_MONGO_PORT:-27017}"
+OPEN_MODE="\${EMA_OPEN_MODE:-webview}"
 NODE_BIN="\${EMA_NODE_PATH:-}"
 MONGO_BIN="\${EMA_MONGO_PATH:-}"
 
@@ -289,7 +298,12 @@ export EMA_SERVER_MONGO_URI="$MONGO_URI"
 export EMA_SERVER_MONGO_DB="\${EMA_MONGO_DB:-ema}"
 export EMA_SERVER_DATA_ROOT="$DATA_ROOT"
 
-echo "EverMemoryArchive is starting at http://$HOST:$PORT/"
+WEBUI_URL="http://$HOST:$PORT/"
+if [ "$OPEN_MODE" != "none" ]; then
+  "$APP_ROOT/open-webui.sh" "$WEBUI_URL" "$OPEN_MODE" "$NODE_BIN" &
+fi
+
+echo "EverMemoryArchive is starting at $WEBUI_URL"
 "$NODE_BIN" "$SERVER_JS"
 `;
 }
@@ -306,6 +320,7 @@ if not defined EMA_DATA_ROOT set "EMA_DATA_ROOT=%APP_ROOT%.ema"
 if not defined EMA_HOST set "EMA_HOST=127.0.0.1"
 if not defined EMA_PORT set "EMA_PORT=3000"
 if not defined EMA_MONGO_PORT set "EMA_MONGO_PORT=27017"
+if not defined EMA_OPEN_MODE set "EMA_OPEN_MODE=webview"
 
 set "NODE_BIN=%EMA_NODE_PATH%"
 if not defined NODE_BIN if exist "%APP_ROOT%portables\\node\\node.exe" set "NODE_BIN=%APP_ROOT%portables\\node\\node.exe"
@@ -338,10 +353,180 @@ set "EMA_SERVER_MONGO_KIND=remote"
 set "EMA_SERVER_MONGO_DB=ema"
 set "EMA_SERVER_DATA_ROOT=%EMA_DATA_ROOT%"
 set "EMA_SERVER_MONGO_URI=%EMA_MONGO_URI%"
+set "EMA_WEBUI_URL=http://%EMA_HOST%:%EMA_PORT%/"
 
-echo EverMemoryArchive is starting at http://%EMA_HOST%:%EMA_PORT%/
+if /I not "%EMA_OPEN_MODE%"=="none" (
+  start "" /B powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%APP_ROOT%open-webui.ps1" -Url "%EMA_WEBUI_URL%" -Mode "%EMA_OPEN_MODE%"
+)
+
+echo EverMemoryArchive is starting at %EMA_WEBUI_URL%
 "%NODE_BIN%" "%SERVER_JS%"
 endlocal
+`;
+}
+
+function posixOpenWebuiScript(): string {
+  return `#!/usr/bin/env bash
+set -euo pipefail
+
+URL="\${1:?URL is required}"
+MODE="\${2:-webview}"
+NODE_BIN="\${3:-node}"
+
+if [ "$MODE" = "none" ]; then
+  exit 0
+fi
+
+wait_for_webui() {
+  "$NODE_BIN" - "$URL" <<'NODE'
+const url = process.argv[2];
+const deadline = Date.now() + 30000;
+
+async function sleep(ms) {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+while (Date.now() < deadline) {
+  try {
+    const response = await fetch(url, { signal: AbortSignal.timeout(1000) });
+    if (response.status < 500) {
+      process.exit(0);
+    }
+  } catch {
+    // Keep waiting until the server starts accepting connections.
+  }
+  await sleep(500);
+}
+
+process.exit(1);
+NODE
+}
+
+open_default_browser() {
+  case "$(uname -s)" in
+    Darwin)
+      open "$URL" >/dev/null 2>&1 &
+      return 0
+      ;;
+  esac
+
+  if command -v xdg-open >/dev/null 2>&1; then
+    xdg-open "$URL" >/dev/null 2>&1 &
+    return 0
+  fi
+  if command -v gio >/dev/null 2>&1; then
+    gio open "$URL" >/dev/null 2>&1 &
+    return 0
+  fi
+  echo "No default browser opener was found. Open $URL manually." >&2
+}
+
+open_webview_window() {
+  case "$(uname -s)" in
+    Darwin)
+      for app in "Microsoft Edge" "Google Chrome" "Chromium" "Brave Browser"; do
+        if open -Ra "$app" >/dev/null 2>&1; then
+          open -na "$app" --args --app="$URL" >/dev/null 2>&1 &
+          return 0
+        fi
+      done
+      ;;
+    *)
+      for command in microsoft-edge-stable microsoft-edge msedge google-chrome-stable google-chrome chromium chromium-browser brave-browser; do
+        if command -v "$command" >/dev/null 2>&1; then
+          "$command" --app="$URL" >/dev/null 2>&1 &
+          return 0
+        fi
+      done
+      ;;
+  esac
+
+  open_default_browser
+}
+
+wait_for_webui || exit 0
+case "$MODE" in
+  browser)
+    open_default_browser
+    ;;
+  webview|"")
+    open_webview_window
+    ;;
+  *)
+    echo "Unknown EMA_OPEN_MODE '$MODE'; falling back to webview." >&2
+    open_webview_window
+    ;;
+esac
+`;
+}
+
+function windowsOpenWebuiScript(): string {
+  return `param(
+  [Parameter(Mandatory = $true)]
+  [string]$Url,
+  [string]$Mode = "webview"
+)
+
+if ($Mode -eq "none") {
+  exit 0
+}
+
+$deadline = (Get-Date).AddSeconds(30)
+$ready = $false
+while ((Get-Date) -lt $deadline) {
+  try {
+    $response = Invoke-WebRequest -UseBasicParsing -Uri $Url -TimeoutSec 1
+    if ($response.StatusCode -lt 500) {
+      $ready = $true
+      break
+    }
+  } catch {
+    Start-Sleep -Milliseconds 500
+    continue
+  }
+  Start-Sleep -Milliseconds 500
+}
+
+if (-not $ready) {
+  exit 0
+}
+
+function Open-DefaultBrowser {
+  Start-Process $Url | Out-Null
+}
+
+function Start-AppModeBrowser([string]$Path) {
+  Start-Process -FilePath $Path -ArgumentList @("--app=$Url") | Out-Null
+}
+
+if ($Mode -eq "browser") {
+  Open-DefaultBrowser
+  exit 0
+}
+
+$commands = @("msedge.exe", "chrome.exe", "chromium.exe", "brave.exe")
+foreach ($command in $commands) {
+  $resolved = Get-Command $command -ErrorAction SilentlyContinue
+  if ($resolved) {
+    Start-AppModeBrowser $resolved.Source
+    exit 0
+  }
+}
+
+$knownPaths = @(
+  "$env:ProgramFiles\\Microsoft\\Edge\\Application\\msedge.exe",
+  "$env:ProgramFiles(x86)\\Microsoft\\Edge\\Application\\msedge.exe",
+  "$env:ProgramFiles\\Google\\Chrome\\Application\\chrome.exe",
+  "$env:ProgramFiles(x86)\\Google\\Chrome\\Application\\chrome.exe"
+)
+foreach ($path in $knownPaths) {
+  if (Test-Path -LiteralPath $path) {
+    Start-AppModeBrowser $path
+    exit 0
+  }
+}
+
+Open-DefaultBrowser
 `;
 }
 
@@ -355,6 +540,14 @@ read -r -p "mongod executable path [PATH or portable]: " MONGO_PATH_INPUT
 read -r -p "MongoDB URI [start local mongod]: " MONGO_URI_INPUT
 read -r -p "WebUI host [127.0.0.1]: " HOST_INPUT
 read -r -p "WebUI port [3000]: " PORT_INPUT
+read -r -p "Use default browser instead of app/webview window? [y/N]: " USE_BROWSER_INPUT
+
+OPEN_MODE="webview"
+case "$USE_BROWSER_INPUT" in
+  y|Y|yes|YES)
+    OPEN_MODE="browser"
+    ;;
+esac
 
 cat > "$APP_ROOT/ema-runtime.sh" <<EOF
 export EMA_NODE_PATH="$NODE_PATH_INPUT"
@@ -362,6 +555,7 @@ export EMA_MONGO_PATH="$MONGO_PATH_INPUT"
 export EMA_MONGO_URI="$MONGO_URI_INPUT"
 export EMA_HOST="\${HOST_INPUT:-127.0.0.1}"
 export EMA_PORT="\${PORT_INPUT:-3000}"
+export EMA_OPEN_MODE="$OPEN_MODE"
 EOF
 
 echo "Wrote $APP_ROOT/ema-runtime.sh"
@@ -377,14 +571,19 @@ set /p EMA_MONGO_PATH=mongod executable path [PATH or portable]:
 set /p EMA_MONGO_URI=MongoDB URI [start local mongod]: 
 set /p EMA_HOST=WebUI host [127.0.0.1]: 
 set /p EMA_PORT=WebUI port [3000]: 
+set /p USE_BROWSER=Use default browser instead of app/webview window? [y/N]: 
 if not defined EMA_HOST set "EMA_HOST=127.0.0.1"
 if not defined EMA_PORT set "EMA_PORT=3000"
+set "EMA_OPEN_MODE=webview"
+if /I "%USE_BROWSER%"=="y" set "EMA_OPEN_MODE=browser"
+if /I "%USE_BROWSER%"=="yes" set "EMA_OPEN_MODE=browser"
 (
   echo set "EMA_NODE_PATH=%EMA_NODE_PATH%"
   echo set "EMA_MONGO_PATH=%EMA_MONGO_PATH%"
   echo set "EMA_MONGO_URI=%EMA_MONGO_URI%"
   echo set "EMA_HOST=%EMA_HOST%"
   echo set "EMA_PORT=%EMA_PORT%"
+  echo set "EMA_OPEN_MODE=%EMA_OPEN_MODE%"
 ) > "%APP_ROOT%ema-runtime.cmd"
 echo Wrote %APP_ROOT%ema-runtime.cmd
 endlocal
@@ -401,6 +600,10 @@ function installText(platform: Platform, kind: PackageKind): string {
   return `EverMemoryArchive ${kind} package for ${platform.label}
 
 Run ${launcher} to start the WebUI.
+
+By default the launcher opens the WebUI in an app/webview-style browser window
+without the normal browser toolbar. Set EMA_OPEN_MODE=browser to use the system
+default browser, or EMA_OPEN_MODE=none to skip opening a window.
 
 portable:
   Bundles Node.js and MongoDB when the platform has upstream MongoDB binaries.

--- a/packages/ema-dist/src/stage.ts
+++ b/packages/ema-dist/src/stage.ts
@@ -180,7 +180,7 @@ async function writeLaunchers(
     windowsStartScript(serverRelativePath),
   );
   await fs.writeFile(
-    path.join(root, "open-webui.ps1"),
+    path.join(root, "open-webui.cmd"),
     windowsOpenWebuiScript(),
   );
   await fs.writeFile(
@@ -356,7 +356,7 @@ set "EMA_SERVER_MONGO_URI=%EMA_MONGO_URI%"
 set "EMA_WEBUI_URL=http://%EMA_HOST%:%EMA_PORT%/"
 
 if /I not "%EMA_OPEN_MODE%"=="none" (
-  start "" /B powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%APP_ROOT%open-webui.ps1" -Url "%EMA_WEBUI_URL%" -Mode "%EMA_OPEN_MODE%"
+  start "" /B "%APP_ROOT%open-webui.cmd" "%EMA_WEBUI_URL%" "%EMA_OPEN_MODE%" "%NODE_BIN%"
 )
 
 echo EverMemoryArchive is starting at %EMA_WEBUI_URL%
@@ -461,72 +461,67 @@ esac
 }
 
 function windowsOpenWebuiScript(): string {
-  return `param(
-  [Parameter(Mandatory = $true)]
-  [string]$Url,
-  [string]$Mode = "webview"
-)
+  return `@echo off
+setlocal EnableExtensions
+set "URL=%~1"
+set "MODE=%~2"
+set "NODE_BIN=%~3"
+if not defined MODE set "MODE=webview"
+if not defined NODE_BIN set "NODE_BIN=node"
+if /I "%MODE%"=="none" exit /b 0
 
-if ($Mode -eq "none") {
-  exit 0
-}
+set "WAITER=%TEMP%\\ema-webui-wait-%RANDOM%%RANDOM%.js"
+> "%WAITER%" echo const url = process.argv[2];
+>> "%WAITER%" echo const deadline = Date.now() + 30000;
+>> "%WAITER%" echo const sleep = ms =^> new Promise^(resolve =^> setTimeout^(resolve, ms^)^);
+>> "%WAITER%" echo ^(async ^(^) =^> {
+>> "%WAITER%" echo   while ^(Date.now^(^) ^< deadline^) {
+>> "%WAITER%" echo     try {
+>> "%WAITER%" echo       const response = await fetch^(url, { signal: AbortSignal.timeout^(1000^) }^);
+>> "%WAITER%" echo       if ^(response.status ^< 500^) process.exit^(0^);
+>> "%WAITER%" echo     } catch {}
+>> "%WAITER%" echo     await sleep^(500^);
+>> "%WAITER%" echo   }
+>> "%WAITER%" echo   process.exit^(1^);
+>> "%WAITER%" echo }^)^(^);
 
-$deadline = (Get-Date).AddSeconds(30)
-$ready = $false
-while ((Get-Date) -lt $deadline) {
-  try {
-    $response = Invoke-WebRequest -UseBasicParsing -Uri $Url -TimeoutSec 1
-    if ($response.StatusCode -lt 500) {
-      $ready = $true
-      break
-    }
-  } catch {
-    Start-Sleep -Milliseconds 500
-    continue
-  }
-  Start-Sleep -Milliseconds 500
-}
+"%NODE_BIN%" "%WAITER%" "%URL%" >nul 2>nul
+set "WAIT_EXIT=%ERRORLEVEL%"
+del "%WAITER%" >nul 2>nul
+if not "%WAIT_EXIT%"=="0" exit /b 0
 
-if (-not $ready) {
-  exit 0
-}
+if /I "%MODE%"=="browser" goto open_default_browser
 
-function Open-DefaultBrowser {
-  Start-Process $Url | Out-Null
-}
+call :try_app_path "%ProgramFiles%\\Microsoft\\Edge\\Application\\msedge.exe"
+if not errorlevel 1 exit /b 0
+call :try_app_path "%ProgramFiles(x86)%\\Microsoft\\Edge\\Application\\msedge.exe"
+if not errorlevel 1 exit /b 0
+call :try_app_path "%ProgramFiles%\\Google\\Chrome\\Application\\chrome.exe"
+if not errorlevel 1 exit /b 0
+call :try_app_path "%ProgramFiles(x86)%\\Google\\Chrome\\Application\\chrome.exe"
+if not errorlevel 1 exit /b 0
+call :try_app_command msedge.exe
+if not errorlevel 1 exit /b 0
+call :try_app_command chrome.exe
+if not errorlevel 1 exit /b 0
+call :try_app_command chromium.exe
+if not errorlevel 1 exit /b 0
+call :try_app_command brave.exe
+if not errorlevel 1 exit /b 0
 
-function Start-AppModeBrowser([string]$Path) {
-  Start-Process -FilePath $Path -ArgumentList @("--app=$Url") | Out-Null
-}
+:open_default_browser
+start "" "%URL%"
+exit /b 0
 
-if ($Mode -eq "browser") {
-  Open-DefaultBrowser
-  exit 0
-}
+:try_app_path
+if not exist "%~1" exit /b 1
+start "" "%~1" --app="%URL%"
+exit /b 0
 
-$commands = @("msedge.exe", "chrome.exe", "chromium.exe", "brave.exe")
-foreach ($command in $commands) {
-  $resolved = Get-Command $command -ErrorAction SilentlyContinue
-  if ($resolved) {
-    Start-AppModeBrowser $resolved.Source
-    exit 0
-  }
-}
-
-$knownPaths = @(
-  "$env:ProgramFiles\\Microsoft\\Edge\\Application\\msedge.exe",
-  "$env:ProgramFiles(x86)\\Microsoft\\Edge\\Application\\msedge.exe",
-  "$env:ProgramFiles\\Google\\Chrome\\Application\\chrome.exe",
-  "$env:ProgramFiles(x86)\\Google\\Chrome\\Application\\chrome.exe"
-)
-foreach ($path in $knownPaths) {
-  if (Test-Path -LiteralPath $path) {
-    Start-AppModeBrowser $path
-    exit 0
-  }
-}
-
-Open-DefaultBrowser
+:try_app_command
+where "%~1" >nul 2>nul || exit /b 1
+start "" "%~1" --app="%URL%"
+exit /b 0
 `;
 }
 

--- a/packages/ema-dist/src/stage.ts
+++ b/packages/ema-dist/src/stage.ts
@@ -8,6 +8,14 @@ import {
   workspaceRoot,
 } from "./paths";
 import type { PackageKind, Platform } from "./platforms";
+import installTextTemplate from "./templates/INSTALL.txt?raw";
+import configureCmdTemplate from "./templates/configure.cmd?raw";
+import configureShTemplate from "./templates/configure.sh?raw";
+import openWebuiCmdTemplate from "./templates/open-webui.cmd?raw";
+import openWebuiShTemplate from "./templates/open-webui.sh?raw";
+import startCmdTemplate from "./templates/start.cmd?raw";
+import startShTemplate from "./templates/start.sh?raw";
+import { renderTemplate } from "./templates";
 
 interface StageOptions {
   readonly platform: Platform;
@@ -231,382 +239,38 @@ async function readServerRelativePath(root: string): Promise<string> {
 }
 
 function posixStartScript(serverRelativePath: string): string {
-  return `#!/usr/bin/env bash
-set -euo pipefail
-
-APP_ROOT="$(cd "$(dirname "\${BASH_SOURCE[0]}")" && pwd)"
-if [ -f "$APP_ROOT/ema-runtime.sh" ]; then
-  # shellcheck disable=SC1091
-  . "$APP_ROOT/ema-runtime.sh"
-fi
-
-SERVER_JS="$APP_ROOT/${serverRelativePath}"
-DATA_ROOT="\${EMA_DATA_ROOT:-$APP_ROOT/.ema}"
-HOST="\${EMA_HOST:-127.0.0.1}"
-PORT="\${EMA_PORT:-3000}"
-MONGO_PORT="\${EMA_MONGO_PORT:-27017}"
-OPEN_MODE="\${EMA_OPEN_MODE:-webview}"
-NODE_BIN="\${EMA_NODE_PATH:-}"
-MONGO_BIN="\${EMA_MONGO_PATH:-}"
-
-if [ -z "$NODE_BIN" ]; then
-  if [ -x "$APP_ROOT/portables/node/bin/node" ]; then
-    NODE_BIN="$APP_ROOT/portables/node/bin/node"
-  else
-    NODE_BIN="$(command -v node || true)"
-  fi
-fi
-
-if [ -z "$NODE_BIN" ]; then
-  echo "Node.js was not found. Run configure.sh or put node on PATH." >&2
-  exit 1
-fi
-
-mkdir -p "$DATA_ROOT/mongodb" "$DATA_ROOT/logs" "$DATA_ROOT/workspace"
-
-MONGO_URI="\${EMA_MONGO_URI:-}"
-MONGO_PID=""
-if [ -z "$MONGO_URI" ]; then
-  if [ -z "$MONGO_BIN" ]; then
-    if [ -x "$APP_ROOT/portables/mongodb/bin/mongod" ]; then
-      MONGO_BIN="$APP_ROOT/portables/mongodb/bin/mongod"
-    else
-      MONGO_BIN="$(command -v mongod || true)"
-    fi
-  fi
-  if [ -z "$MONGO_BIN" ]; then
-    echo "MongoDB was not found. Run configure.sh, set EMA_MONGO_URI, or put mongod on PATH." >&2
-    exit 1
-  fi
-  MONGO_URI="mongodb://127.0.0.1:$MONGO_PORT/"
-  "$MONGO_BIN" --dbpath "$DATA_ROOT/mongodb" --port "$MONGO_PORT" --bind_ip 127.0.0.1 --logpath "$DATA_ROOT/logs/mongodb.log" &
-  MONGO_PID="$!"
-fi
-
-cleanup() {
-  if [ -n "$MONGO_PID" ]; then
-    kill "$MONGO_PID" >/dev/null 2>&1 || true
-  fi
-}
-trap cleanup EXIT INT TERM
-
-export HOSTNAME="$HOST"
-export PORT="$PORT"
-export EMA_SERVER_MODE=prod
-export EMA_SERVER_MONGO_KIND=remote
-export EMA_SERVER_MONGO_URI="$MONGO_URI"
-export EMA_SERVER_MONGO_DB="\${EMA_MONGO_DB:-ema}"
-export EMA_SERVER_DATA_ROOT="$DATA_ROOT"
-
-WEBUI_URL="http://$HOST:$PORT/"
-if [ "$OPEN_MODE" != "none" ]; then
-  "$APP_ROOT/open-webui.sh" "$WEBUI_URL" "$OPEN_MODE" "$NODE_BIN" &
-fi
-
-echo "EverMemoryArchive is starting at $WEBUI_URL"
-"$NODE_BIN" "$SERVER_JS"
-`;
+  return renderTemplate(startShTemplate, { serverRelativePath });
 }
 
 function windowsStartScript(serverRelativePath: string): string {
-  const windowsServerPath = serverRelativePath.split("/").join("\\");
-  return `@echo off
-setlocal
-set "APP_ROOT=%~dp0"
-if exist "%APP_ROOT%ema-runtime.cmd" call "%APP_ROOT%ema-runtime.cmd"
-
-set "SERVER_JS=%APP_ROOT%${windowsServerPath}"
-if not defined EMA_DATA_ROOT set "EMA_DATA_ROOT=%APP_ROOT%.ema"
-if not defined EMA_HOST set "EMA_HOST=127.0.0.1"
-if not defined EMA_PORT set "EMA_PORT=3000"
-if not defined EMA_MONGO_PORT set "EMA_MONGO_PORT=27017"
-if not defined EMA_OPEN_MODE set "EMA_OPEN_MODE=webview"
-
-set "NODE_BIN=%EMA_NODE_PATH%"
-if not defined NODE_BIN if exist "%APP_ROOT%portables\\node\\node.exe" set "NODE_BIN=%APP_ROOT%portables\\node\\node.exe"
-if not defined NODE_BIN for %%I in (node.exe) do set "NODE_BIN=%%~$PATH:I"
-if not defined NODE_BIN (
-  echo Node.js was not found. Run configure.cmd or put node on PATH.
-  exit /b 1
-)
-
-if not exist "%EMA_DATA_ROOT%\\mongodb" mkdir "%EMA_DATA_ROOT%\\mongodb"
-if not exist "%EMA_DATA_ROOT%\\logs" mkdir "%EMA_DATA_ROOT%\\logs"
-if not exist "%EMA_DATA_ROOT%\\workspace" mkdir "%EMA_DATA_ROOT%\\workspace"
-
-if not defined EMA_MONGO_URI (
-  set "MONGO_BIN=%EMA_MONGO_PATH%"
-  if not defined MONGO_BIN if exist "%APP_ROOT%portables\\mongodb\\bin\\mongod.exe" set "MONGO_BIN=%APP_ROOT%portables\\mongodb\\bin\\mongod.exe"
-  if not defined MONGO_BIN for %%I in (mongod.exe) do set "MONGO_BIN=%%~$PATH:I"
-  if not defined MONGO_BIN (
-    echo MongoDB was not found. Run configure.cmd, set EMA_MONGO_URI, or put mongod on PATH.
-    exit /b 1
-  )
-  set "EMA_MONGO_URI=mongodb://127.0.0.1:%EMA_MONGO_PORT%/"
-  start "EMA MongoDB" /B "%MONGO_BIN%" --dbpath "%EMA_DATA_ROOT%\\mongodb" --port "%EMA_MONGO_PORT%" --bind_ip 127.0.0.1 --logpath "%EMA_DATA_ROOT%\\logs\\mongodb.log"
-)
-
-set "HOSTNAME=%EMA_HOST%"
-set "PORT=%EMA_PORT%"
-set "EMA_SERVER_MODE=prod"
-set "EMA_SERVER_MONGO_KIND=remote"
-set "EMA_SERVER_MONGO_DB=ema"
-set "EMA_SERVER_DATA_ROOT=%EMA_DATA_ROOT%"
-set "EMA_SERVER_MONGO_URI=%EMA_MONGO_URI%"
-set "EMA_WEBUI_URL=http://%EMA_HOST%:%EMA_PORT%/"
-
-if /I not "%EMA_OPEN_MODE%"=="none" (
-  start "" /B "%APP_ROOT%open-webui.cmd" "%EMA_WEBUI_URL%" "%EMA_OPEN_MODE%" "%NODE_BIN%"
-)
-
-echo EverMemoryArchive is starting at %EMA_WEBUI_URL%
-"%NODE_BIN%" "%SERVER_JS%"
-endlocal
-`;
+  return renderTemplate(startCmdTemplate, {
+    serverRelativePath: serverRelativePath.split("/").join("\\"),
+  });
 }
 
 function posixOpenWebuiScript(): string {
-  return `#!/usr/bin/env bash
-set -euo pipefail
-
-URL="\${1:?URL is required}"
-MODE="\${2:-webview}"
-NODE_BIN="\${3:-node}"
-
-if [ "$MODE" = "none" ]; then
-  exit 0
-fi
-
-wait_for_webui() {
-  "$NODE_BIN" - "$URL" <<'NODE'
-const url = process.argv[2];
-const deadline = Date.now() + 30000;
-
-async function sleep(ms) {
-  await new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-while (Date.now() < deadline) {
-  try {
-    const response = await fetch(url, { signal: AbortSignal.timeout(1000) });
-    if (response.status < 500) {
-      process.exit(0);
-    }
-  } catch {
-    // Keep waiting until the server starts accepting connections.
-  }
-  await sleep(500);
-}
-
-process.exit(1);
-NODE
-}
-
-open_default_browser() {
-  case "$(uname -s)" in
-    Darwin)
-      open "$URL" >/dev/null 2>&1 &
-      return 0
-      ;;
-  esac
-
-  if command -v xdg-open >/dev/null 2>&1; then
-    xdg-open "$URL" >/dev/null 2>&1 &
-    return 0
-  fi
-  if command -v gio >/dev/null 2>&1; then
-    gio open "$URL" >/dev/null 2>&1 &
-    return 0
-  fi
-  echo "No default browser opener was found. Open $URL manually." >&2
-}
-
-open_webview_window() {
-  case "$(uname -s)" in
-    Darwin)
-      for app in "Microsoft Edge" "Google Chrome" "Chromium" "Brave Browser"; do
-        if open -Ra "$app" >/dev/null 2>&1; then
-          open -na "$app" --args --app="$URL" >/dev/null 2>&1 &
-          return 0
-        fi
-      done
-      ;;
-    *)
-      for command in microsoft-edge-stable microsoft-edge msedge google-chrome-stable google-chrome chromium chromium-browser brave-browser; do
-        if command -v "$command" >/dev/null 2>&1; then
-          "$command" --app="$URL" >/dev/null 2>&1 &
-          return 0
-        fi
-      done
-      ;;
-  esac
-
-  open_default_browser
-}
-
-wait_for_webui || exit 0
-case "$MODE" in
-  browser)
-    open_default_browser
-    ;;
-  webview|"")
-    open_webview_window
-    ;;
-  *)
-    echo "Unknown EMA_OPEN_MODE '$MODE'; falling back to webview." >&2
-    open_webview_window
-    ;;
-esac
-`;
+  return openWebuiShTemplate;
 }
 
 function windowsOpenWebuiScript(): string {
-  return `@echo off
-setlocal EnableExtensions
-set "URL=%~1"
-set "MODE=%~2"
-set "NODE_BIN=%~3"
-if not defined MODE set "MODE=webview"
-if not defined NODE_BIN set "NODE_BIN=node"
-if /I "%MODE%"=="none" exit /b 0
-
-set "WAITER=%TEMP%\\ema-webui-wait-%RANDOM%%RANDOM%.js"
-> "%WAITER%" echo const url = process.argv[2];
->> "%WAITER%" echo const deadline = Date.now() + 30000;
->> "%WAITER%" echo const sleep = ms =^> new Promise^(resolve =^> setTimeout^(resolve, ms^)^);
->> "%WAITER%" echo ^(async ^(^) =^> {
->> "%WAITER%" echo   while ^(Date.now^(^) ^< deadline^) {
->> "%WAITER%" echo     try {
->> "%WAITER%" echo       const response = await fetch^(url, { signal: AbortSignal.timeout^(1000^) }^);
->> "%WAITER%" echo       if ^(response.status ^< 500^) process.exit^(0^);
->> "%WAITER%" echo     } catch {}
->> "%WAITER%" echo     await sleep^(500^);
->> "%WAITER%" echo   }
->> "%WAITER%" echo   process.exit^(1^);
->> "%WAITER%" echo }^)^(^);
-
-"%NODE_BIN%" "%WAITER%" "%URL%" >nul 2>nul
-set "WAIT_EXIT=%ERRORLEVEL%"
-del "%WAITER%" >nul 2>nul
-if not "%WAIT_EXIT%"=="0" exit /b 0
-
-if /I "%MODE%"=="browser" goto open_default_browser
-
-call :try_app_path "%ProgramFiles%\\Microsoft\\Edge\\Application\\msedge.exe"
-if not errorlevel 1 exit /b 0
-call :try_app_path "%ProgramFiles(x86)%\\Microsoft\\Edge\\Application\\msedge.exe"
-if not errorlevel 1 exit /b 0
-call :try_app_path "%ProgramFiles%\\Google\\Chrome\\Application\\chrome.exe"
-if not errorlevel 1 exit /b 0
-call :try_app_path "%ProgramFiles(x86)%\\Google\\Chrome\\Application\\chrome.exe"
-if not errorlevel 1 exit /b 0
-call :try_app_command msedge.exe
-if not errorlevel 1 exit /b 0
-call :try_app_command chrome.exe
-if not errorlevel 1 exit /b 0
-call :try_app_command chromium.exe
-if not errorlevel 1 exit /b 0
-call :try_app_command brave.exe
-if not errorlevel 1 exit /b 0
-
-:open_default_browser
-start "" "%URL%"
-exit /b 0
-
-:try_app_path
-if not exist "%~1" exit /b 1
-start "" "%~1" --app="%URL%"
-exit /b 0
-
-:try_app_command
-where "%~1" >nul 2>nul || exit /b 1
-start "" "%~1" --app="%URL%"
-exit /b 0
-`;
+  return openWebuiCmdTemplate;
 }
 
 function posixConfigureScript(): string {
-  return `#!/usr/bin/env bash
-set -euo pipefail
-
-APP_ROOT="$(cd "$(dirname "\${BASH_SOURCE[0]}")" && pwd)"
-read -r -p "Node executable path [PATH or portable]: " NODE_PATH_INPUT
-read -r -p "mongod executable path [PATH or portable]: " MONGO_PATH_INPUT
-read -r -p "MongoDB URI [start local mongod]: " MONGO_URI_INPUT
-read -r -p "WebUI host [127.0.0.1]: " HOST_INPUT
-read -r -p "WebUI port [3000]: " PORT_INPUT
-read -r -p "Use default browser instead of app/webview window? [y/N]: " USE_BROWSER_INPUT
-
-OPEN_MODE="webview"
-case "$USE_BROWSER_INPUT" in
-  y|Y|yes|YES)
-    OPEN_MODE="browser"
-    ;;
-esac
-
-cat > "$APP_ROOT/ema-runtime.sh" <<EOF
-export EMA_NODE_PATH="$NODE_PATH_INPUT"
-export EMA_MONGO_PATH="$MONGO_PATH_INPUT"
-export EMA_MONGO_URI="$MONGO_URI_INPUT"
-export EMA_HOST="\${HOST_INPUT:-127.0.0.1}"
-export EMA_PORT="\${PORT_INPUT:-3000}"
-export EMA_OPEN_MODE="$OPEN_MODE"
-EOF
-
-echo "Wrote $APP_ROOT/ema-runtime.sh"
-`;
+  return configureShTemplate;
 }
 
 function windowsConfigureScript(): string {
-  return `@echo off
-setlocal
-set "APP_ROOT=%~dp0"
-set /p EMA_NODE_PATH=Node executable path [PATH or portable]: 
-set /p EMA_MONGO_PATH=mongod executable path [PATH or portable]: 
-set /p EMA_MONGO_URI=MongoDB URI [start local mongod]: 
-set /p EMA_HOST=WebUI host [127.0.0.1]: 
-set /p EMA_PORT=WebUI port [3000]: 
-set /p USE_BROWSER=Use default browser instead of app/webview window? [y/N]: 
-if not defined EMA_HOST set "EMA_HOST=127.0.0.1"
-if not defined EMA_PORT set "EMA_PORT=3000"
-set "EMA_OPEN_MODE=webview"
-if /I "%USE_BROWSER%"=="y" set "EMA_OPEN_MODE=browser"
-if /I "%USE_BROWSER%"=="yes" set "EMA_OPEN_MODE=browser"
-(
-  echo set "EMA_NODE_PATH=%EMA_NODE_PATH%"
-  echo set "EMA_MONGO_PATH=%EMA_MONGO_PATH%"
-  echo set "EMA_MONGO_URI=%EMA_MONGO_URI%"
-  echo set "EMA_HOST=%EMA_HOST%"
-  echo set "EMA_PORT=%EMA_PORT%"
-  echo set "EMA_OPEN_MODE=%EMA_OPEN_MODE%"
-) > "%APP_ROOT%ema-runtime.cmd"
-echo Wrote %APP_ROOT%ema-runtime.cmd
-endlocal
-`;
+  return configureCmdTemplate;
 }
 
 function installText(platform: Platform, kind: PackageKind): string {
-  const launcher =
-    platform.os === "win32"
-      ? "start.cmd"
-      : platform.os === "darwin"
-        ? "start.sh"
-        : "start.sh";
-  return `EverMemoryArchive ${kind} package for ${platform.label}
-
-Run ${launcher} to start the WebUI.
-
-By default the launcher opens the WebUI in an app/webview-style browser window
-without the normal browser toolbar. Set EMA_OPEN_MODE=browser to use the system
-default browser, or EMA_OPEN_MODE=none to skip opening a window.
-
-portable:
-  Bundles Node.js and MongoDB when the platform has upstream MongoDB binaries.
-
-minimal:
-  Run configure.sh/configure.cmd to set Node.js and MongoDB paths, or put node
-  and mongod on PATH. You may also set EMA_MONGO_URI to use an external MongoDB.
-`;
+  const launcher = platform.os === "win32" ? "start.cmd" : "start.sh";
+  return renderTemplate(installTextTemplate, {
+    kind,
+    launcher,
+    platformLabel: platform.label,
+  });
 }
 
 async function copyIfExists(

--- a/packages/ema-dist/src/templates.ts
+++ b/packages/ema-dist/src/templates.ts
@@ -1,0 +1,14 @@
+const TOKEN_PATTERN = /\{\{([A-Za-z0-9_]+)\}\}/gu;
+
+export function renderTemplate(
+  template: string,
+  values: Readonly<Record<string, string>>,
+): string {
+  return template.replace(TOKEN_PATTERN, (token, key: string) => {
+    const value = values[key];
+    if (value === undefined) {
+      throw new Error(`Missing template value for ${token}.`);
+    }
+    return value;
+  });
+}

--- a/packages/ema-dist/src/templates/INSTALL.txt
+++ b/packages/ema-dist/src/templates/INSTALL.txt
@@ -1,0 +1,14 @@
+EverMemoryArchive {{kind}} package for {{platformLabel}}
+
+Run {{launcher}} to start the WebUI.
+
+By default the launcher opens the WebUI in an app/webview-style browser window
+without the normal browser toolbar. Set EMA_OPEN_MODE=browser to use the system
+default browser, or EMA_OPEN_MODE=none to skip opening a window.
+
+portable:
+  Bundles Node.js and MongoDB when the platform has upstream MongoDB binaries.
+
+minimal:
+  Run configure.sh/configure.cmd to set Node.js and MongoDB paths, or put node
+  and mongod on PATH. You may also set EMA_MONGO_URI to use an external MongoDB.

--- a/packages/ema-dist/src/templates/configure.cmd
+++ b/packages/ema-dist/src/templates/configure.cmd
@@ -1,12 +1,12 @@
 @echo off
 setlocal
 set "APP_ROOT=%~dp0"
-set /p EMA_NODE_PATH=Node executable path [PATH or portable]: 
-set /p EMA_MONGO_PATH=mongod executable path [PATH or portable]: 
-set /p EMA_MONGO_URI=MongoDB URI [start local mongod]: 
-set /p EMA_HOST=WebUI host [127.0.0.1]: 
-set /p EMA_PORT=WebUI port [3000]: 
-set /p USE_BROWSER=Use default browser instead of app/webview window? [y/N]: 
+set /p "EMA_NODE_PATH=Node executable path [PATH or portable]: "
+set /p "EMA_MONGO_PATH=mongod executable path [PATH or portable]: "
+set /p "EMA_MONGO_URI=MongoDB URI [start local mongod]: "
+set /p "EMA_HOST=WebUI host [127.0.0.1]: "
+set /p "EMA_PORT=WebUI port [3000]: "
+set /p "USE_BROWSER=Use default browser instead of app/webview window? [y/N]: "
 if not defined EMA_HOST set "EMA_HOST=127.0.0.1"
 if not defined EMA_PORT set "EMA_PORT=3000"
 set "EMA_OPEN_MODE=webview"

--- a/packages/ema-dist/src/templates/configure.cmd
+++ b/packages/ema-dist/src/templates/configure.cmd
@@ -1,0 +1,24 @@
+@echo off
+setlocal
+set "APP_ROOT=%~dp0"
+set /p EMA_NODE_PATH=Node executable path [PATH or portable]: 
+set /p EMA_MONGO_PATH=mongod executable path [PATH or portable]: 
+set /p EMA_MONGO_URI=MongoDB URI [start local mongod]: 
+set /p EMA_HOST=WebUI host [127.0.0.1]: 
+set /p EMA_PORT=WebUI port [3000]: 
+set /p USE_BROWSER=Use default browser instead of app/webview window? [y/N]: 
+if not defined EMA_HOST set "EMA_HOST=127.0.0.1"
+if not defined EMA_PORT set "EMA_PORT=3000"
+set "EMA_OPEN_MODE=webview"
+if /I "%USE_BROWSER%"=="y" set "EMA_OPEN_MODE=browser"
+if /I "%USE_BROWSER%"=="yes" set "EMA_OPEN_MODE=browser"
+(
+  echo set "EMA_NODE_PATH=%EMA_NODE_PATH%"
+  echo set "EMA_MONGO_PATH=%EMA_MONGO_PATH%"
+  echo set "EMA_MONGO_URI=%EMA_MONGO_URI%"
+  echo set "EMA_HOST=%EMA_HOST%"
+  echo set "EMA_PORT=%EMA_PORT%"
+  echo set "EMA_OPEN_MODE=%EMA_OPEN_MODE%"
+) > "%APP_ROOT%ema-runtime.cmd"
+echo Wrote %APP_ROOT%ema-runtime.cmd
+endlocal

--- a/packages/ema-dist/src/templates/configure.sh
+++ b/packages/ema-dist/src/templates/configure.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+read -r -p "Node executable path [PATH or portable]: " NODE_PATH_INPUT
+read -r -p "mongod executable path [PATH or portable]: " MONGO_PATH_INPUT
+read -r -p "MongoDB URI [start local mongod]: " MONGO_URI_INPUT
+read -r -p "WebUI host [127.0.0.1]: " HOST_INPUT
+read -r -p "WebUI port [3000]: " PORT_INPUT
+read -r -p "Use default browser instead of app/webview window? [y/N]: " USE_BROWSER_INPUT
+
+OPEN_MODE="webview"
+case "$USE_BROWSER_INPUT" in
+  y|Y|yes|YES)
+    OPEN_MODE="browser"
+    ;;
+esac
+
+cat > "$APP_ROOT/ema-runtime.sh" <<EOF
+export EMA_NODE_PATH="$NODE_PATH_INPUT"
+export EMA_MONGO_PATH="$MONGO_PATH_INPUT"
+export EMA_MONGO_URI="$MONGO_URI_INPUT"
+export EMA_HOST="${HOST_INPUT:-127.0.0.1}"
+export EMA_PORT="${PORT_INPUT:-3000}"
+export EMA_OPEN_MODE="$OPEN_MODE"
+EOF
+
+echo "Wrote $APP_ROOT/ema-runtime.sh"

--- a/packages/ema-dist/src/templates/installer.cmd
+++ b/packages/ema-dist/src/templates/installer.cmd
@@ -1,0 +1,108 @@
+@echo off
+setlocal EnableExtensions
+set "PLATFORM={{platformId}}"
+set "KIND={{kind}}"
+set "TMP_DIR=%TEMP%\ema-installer-%RANDOM%%RANDOM%%RANDOM%"
+set "EXIT_CODE=0"
+
+mkdir "%TMP_DIR%" >nul 2>nul
+if errorlevel 1 (
+  echo Failed to create temporary directory: "%TMP_DIR%"
+  exit /b 1
+)
+
+set "SEVENZIP_B64=%TMP_DIR%\7za.b64"
+set "ARCHIVE_B64=%TMP_DIR%\payload.b64"
+set "SEVENZIP_PATH=%TMP_DIR%\7za.exe"
+set "ARCHIVE_PATH=%TMP_DIR%\payload.7z"
+
+call :extract_section EMA_SEVENZIP "%SEVENZIP_B64%" || goto fail
+call :decode_base64 "%SEVENZIP_B64%" "%SEVENZIP_PATH%" || goto fail
+call :extract_section EMA_ARCHIVE "%ARCHIVE_B64%" || goto fail
+call :decode_base64 "%ARCHIVE_B64%" "%ARCHIVE_PATH%" || goto fail
+
+set "DEFAULT_PARENT=%USERPROFILE%"
+set /p INSTALL_PARENT=Install parent directory [%DEFAULT_PARENT%]: 
+if not defined INSTALL_PARENT set "INSTALL_PARENT=%DEFAULT_PARENT%"
+mkdir "%INSTALL_PARENT%" >nul 2>nul
+
+"%SEVENZIP_PATH%" x "%ARCHIVE_PATH%" "-o%INSTALL_PARENT%" -y
+if errorlevel 1 goto fail
+
+set "APP_DIR=%INSTALL_PARENT%\EverMemoryArchive"
+set "NODE_PATH_INPUT="
+set "MONGO_PATH_INPUT="
+set "MONGO_URI_INPUT="
+if /I "%KIND%"=="minimal" (
+  set /p NODE_PATH_INPUT=Node executable path [PATH]: 
+  set /p MONGO_PATH_INPUT=mongod executable path [PATH]: 
+  set /p MONGO_URI_INPUT=MongoDB URI [start local mongod]: 
+)
+
+set "OPEN_MODE=webview"
+set /p USE_BROWSER=Use default browser instead of app/webview window? [y/N]: 
+if /I "%USE_BROWSER%"=="y" set "OPEN_MODE=browser"
+if /I "%USE_BROWSER%"=="yes" set "OPEN_MODE=browser"
+
+> "%APP_DIR%\ema-runtime.cmd" echo set "EMA_NODE_PATH=%NODE_PATH_INPUT%"
+>> "%APP_DIR%\ema-runtime.cmd" echo set "EMA_MONGO_PATH=%MONGO_PATH_INPUT%"
+>> "%APP_DIR%\ema-runtime.cmd" echo set "EMA_MONGO_URI=%MONGO_URI_INPUT%"
+>> "%APP_DIR%\ema-runtime.cmd" echo set "EMA_HOST=127.0.0.1"
+>> "%APP_DIR%\ema-runtime.cmd" echo set "EMA_PORT=3000"
+>> "%APP_DIR%\ema-runtime.cmd" echo set "EMA_OPEN_MODE=%OPEN_MODE%"
+
+set /p CREATE_SHORTCUT=Create desktop shortcut? [Y/n]: 
+if not defined CREATE_SHORTCUT set "CREATE_SHORTCUT=Y"
+if /I "%CREATE_SHORTCUT%"=="y" call :create_shortcut
+if /I "%CREATE_SHORTCUT%"=="yes" call :create_shortcut
+
+echo Installed EverMemoryArchive to "%APP_DIR%"
+echo Run "%APP_DIR%\start.cmd" to start.
+goto cleanup
+
+:fail
+set "EXIT_CODE=1"
+echo Installation failed.
+goto cleanup
+
+:cleanup
+if exist "%TMP_DIR%" rd /s /q "%TMP_DIR%" >nul 2>nul
+exit /b %EXIT_CODE%
+
+:decode_base64
+certutil -f -decode "%~1" "%~2" >nul 2>nul
+if errorlevel 1 (
+  echo Failed to decode "%~1". certutil.exe is required on Windows.
+  exit /b 1
+)
+exit /b 0
+
+:extract_section
+set "SECTION=%~1"
+set "OUT_FILE=%~2"
+set "INSIDE="
+> "%OUT_FILE%" (
+  for /f "usebackq delims=" %%L in ("%~f0") do (
+    if "%%L"=="__%SECTION%_END__" set "INSIDE="
+    if defined INSIDE echo(%%L
+    if "%%L"=="__%SECTION%_BEGIN__" set "INSIDE=1"
+  )
+)
+exit /b 0
+
+:create_shortcut
+set "DESKTOP=%USERPROFILE%\Desktop"
+if not exist "%DESKTOP%" exit /b 0
+set "SHORTCUT=%DESKTOP%\EverMemoryArchive.cmd"
+> "%SHORTCUT%" echo @echo off
+>> "%SHORTCUT%" echo cd /d "%APP_DIR%"
+>> "%SHORTCUT%" echo call "%APP_DIR%\start.cmd"
+echo Created "%SHORTCUT%"
+exit /b 0
+
+__EMA_SEVENZIP_BEGIN__
+{{sevenZipBase64}}
+__EMA_SEVENZIP_END__
+__EMA_ARCHIVE_BEGIN__
+{{archiveBase64}}
+__EMA_ARCHIVE_END__

--- a/packages/ema-dist/src/templates/installer.cmd
+++ b/packages/ema-dist/src/templates/installer.cmd
@@ -22,7 +22,7 @@ call :extract_section EMA_ARCHIVE "%ARCHIVE_B64%" || goto fail
 call :decode_base64 "%ARCHIVE_B64%" "%ARCHIVE_PATH%" || goto fail
 
 set "DEFAULT_PARENT=%USERPROFILE%"
-set /p INSTALL_PARENT=Install parent directory [%DEFAULT_PARENT%]: 
+set /p "INSTALL_PARENT=Install parent directory [%DEFAULT_PARENT%]: "
 if not defined INSTALL_PARENT set "INSTALL_PARENT=%DEFAULT_PARENT%"
 mkdir "%INSTALL_PARENT%" >nul 2>nul
 
@@ -34,13 +34,13 @@ set "NODE_PATH_INPUT="
 set "MONGO_PATH_INPUT="
 set "MONGO_URI_INPUT="
 if /I "%KIND%"=="minimal" (
-  set /p NODE_PATH_INPUT=Node executable path [PATH]: 
-  set /p MONGO_PATH_INPUT=mongod executable path [PATH]: 
-  set /p MONGO_URI_INPUT=MongoDB URI [start local mongod]: 
+  set /p "NODE_PATH_INPUT=Node executable path [PATH]: "
+  set /p "MONGO_PATH_INPUT=mongod executable path [PATH]: "
+  set /p "MONGO_URI_INPUT=MongoDB URI [start local mongod]: "
 )
 
 set "OPEN_MODE=webview"
-set /p USE_BROWSER=Use default browser instead of app/webview window? [y/N]: 
+set /p "USE_BROWSER=Use default browser instead of app/webview window? [y/N]: "
 if /I "%USE_BROWSER%"=="y" set "OPEN_MODE=browser"
 if /I "%USE_BROWSER%"=="yes" set "OPEN_MODE=browser"
 
@@ -51,7 +51,7 @@ if /I "%USE_BROWSER%"=="yes" set "OPEN_MODE=browser"
 >> "%APP_DIR%\ema-runtime.cmd" echo set "EMA_PORT=3000"
 >> "%APP_DIR%\ema-runtime.cmd" echo set "EMA_OPEN_MODE=%OPEN_MODE%"
 
-set /p CREATE_SHORTCUT=Create desktop shortcut? [Y/n]: 
+set /p "CREATE_SHORTCUT=Create desktop shortcut? [Y/n]: "
 if not defined CREATE_SHORTCUT set "CREATE_SHORTCUT=Y"
 if /I "%CREATE_SHORTCUT%"=="y" call :create_shortcut
 if /I "%CREATE_SHORTCUT%"=="yes" call :create_shortcut

--- a/packages/ema-dist/src/templates/installer.sh
+++ b/packages/ema-dist/src/templates/installer.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PLATFORM="{{platformId}}"
+KIND="{{kind}}"
+TMP_DIR="$(mktemp -d)"
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT INT TERM
+
+extract_section() {
+  awk "/^__EMA_$1_BEGIN__$/ {flag=1; next} /^__EMA_$1_END__$/ {flag=0} flag {print}" "$0"
+}
+
+decode_section() {
+  if base64 --help 2>/dev/null | grep -q -- "--decode"; then
+    extract_section "$1" | base64 --decode > "$2"
+  else
+    extract_section "$1" | base64 -D > "$2"
+  fi
+}
+
+SEVENZIP="$TMP_DIR/7zz"
+ARCHIVE="$TMP_DIR/payload.7z"
+decode_section SEVENZIP "$SEVENZIP"
+decode_section ARCHIVE "$ARCHIVE"
+chmod +x "$SEVENZIP"
+
+DEFAULT_PARENT="${HOME:-.}"
+printf "Install parent directory [%s]: " "$DEFAULT_PARENT"
+read -r INSTALL_PARENT
+INSTALL_PARENT="${INSTALL_PARENT:-$DEFAULT_PARENT}"
+mkdir -p "$INSTALL_PARENT"
+
+"$SEVENZIP" x "$ARCHIVE" "-o$INSTALL_PARENT" -y
+APP_DIR="$INSTALL_PARENT/EverMemoryArchive"
+chmod +x "$APP_DIR/start.sh" "$APP_DIR/configure.sh" 2>/dev/null || true
+
+NODE_PATH_INPUT=""
+MONGO_PATH_INPUT=""
+MONGO_URI_INPUT=""
+if [ "$KIND" = "minimal" ]; then
+  printf "Node executable path [PATH]: "
+  read -r NODE_PATH_INPUT
+  printf "mongod executable path [PATH]: "
+  read -r MONGO_PATH_INPUT
+  printf "MongoDB URI [start local mongod]: "
+  read -r MONGO_URI_INPUT
+fi
+
+OPEN_MODE="webview"
+printf "Use default browser instead of app/webview window? [y/N]: "
+read -r USE_BROWSER_INPUT
+case "$USE_BROWSER_INPUT" in
+  y|Y|yes|YES)
+    OPEN_MODE="browser"
+    ;;
+esac
+
+cat > "$APP_DIR/ema-runtime.sh" <<EOF
+export EMA_NODE_PATH="$NODE_PATH_INPUT"
+export EMA_MONGO_PATH="$MONGO_PATH_INPUT"
+export EMA_MONGO_URI="$MONGO_URI_INPUT"
+export EMA_HOST="127.0.0.1"
+export EMA_PORT="3000"
+export EMA_OPEN_MODE="$OPEN_MODE"
+EOF
+
+printf "Create shortcut? [Y/n]: "
+read -r CREATE_SHORTCUT
+CREATE_SHORTCUT="${CREATE_SHORTCUT:-Y}"
+case "$CREATE_SHORTCUT" in
+  y|Y|yes|YES)
+    if [ "$PLATFORM" = "darwin-x64" ] || [ "$PLATFORM" = "darwin-arm64" ]; then
+      SHORTCUT="$HOME/Desktop/EverMemoryArchive.command"
+      cat > "$SHORTCUT" <<EOF
+#!/usr/bin/env bash
+cd "$APP_DIR"
+exec ./start.sh
+EOF
+      chmod +x "$SHORTCUT"
+    else
+      mkdir -p "$HOME/.local/share/applications"
+      DESKTOP_FILE="$HOME/.local/share/applications/evermemoryarchive.desktop"
+      cat > "$DESKTOP_FILE" <<EOF
+[Desktop Entry]
+Type=Application
+Name=EverMemoryArchive
+Exec=$APP_DIR/start.sh
+Path=$APP_DIR
+Terminal=true
+Categories=Utility;
+EOF
+      if [ -d "$HOME/Desktop" ]; then
+        cp "$DESKTOP_FILE" "$HOME/Desktop/EverMemoryArchive.desktop"
+        chmod +x "$HOME/Desktop/EverMemoryArchive.desktop"
+      fi
+    fi
+    ;;
+esac
+
+echo "Installed EverMemoryArchive to $APP_DIR"
+echo "Run $APP_DIR/start.sh to start."
+exit 0
+
+__EMA_SEVENZIP_BEGIN__
+{{sevenZipBase64}}
+__EMA_SEVENZIP_END__
+__EMA_ARCHIVE_BEGIN__
+{{archiveBase64}}
+__EMA_ARCHIVE_END__

--- a/packages/ema-dist/src/templates/open-webui.cmd
+++ b/packages/ema-dist/src/templates/open-webui.cmd
@@ -1,0 +1,61 @@
+@echo off
+setlocal EnableExtensions
+set "URL=%~1"
+set "MODE=%~2"
+set "NODE_BIN=%~3"
+if not defined MODE set "MODE=webview"
+if not defined NODE_BIN set "NODE_BIN=node"
+if /I "%MODE%"=="none" exit /b 0
+
+set "WAITER=%TEMP%\ema-webui-wait-%RANDOM%%RANDOM%.js"
+> "%WAITER%" echo const url = process.argv[2];
+>> "%WAITER%" echo const deadline = Date.now() + 30000;
+>> "%WAITER%" echo const sleep = ms =^> new Promise^(resolve =^> setTimeout^(resolve, ms^)^);
+>> "%WAITER%" echo ^(async ^(^) =^> {
+>> "%WAITER%" echo   while ^(Date.now^(^) ^< deadline^) {
+>> "%WAITER%" echo     try {
+>> "%WAITER%" echo       const response = await fetch^(url, { signal: AbortSignal.timeout^(1000^) }^);
+>> "%WAITER%" echo       if ^(response.status ^< 500^) process.exit^(0^);
+>> "%WAITER%" echo     } catch {}
+>> "%WAITER%" echo     await sleep^(500^);
+>> "%WAITER%" echo   }
+>> "%WAITER%" echo   process.exit^(1^);
+>> "%WAITER%" echo }^)^(^);
+
+"%NODE_BIN%" "%WAITER%" "%URL%" >nul 2>nul
+set "WAIT_EXIT=%ERRORLEVEL%"
+del "%WAITER%" >nul 2>nul
+if not "%WAIT_EXIT%"=="0" exit /b 0
+
+if /I "%MODE%"=="browser" goto open_default_browser
+
+call :try_app_path "%ProgramFiles%\Microsoft\Edge\Application\msedge.exe"
+if not errorlevel 1 exit /b 0
+call :try_app_path "%ProgramFiles(x86)%\Microsoft\Edge\Application\msedge.exe"
+if not errorlevel 1 exit /b 0
+call :try_app_path "%ProgramFiles%\Google\Chrome\Application\chrome.exe"
+if not errorlevel 1 exit /b 0
+call :try_app_path "%ProgramFiles(x86)%\Google\Chrome\Application\chrome.exe"
+if not errorlevel 1 exit /b 0
+call :try_app_command msedge.exe
+if not errorlevel 1 exit /b 0
+call :try_app_command chrome.exe
+if not errorlevel 1 exit /b 0
+call :try_app_command chromium.exe
+if not errorlevel 1 exit /b 0
+call :try_app_command brave.exe
+if not errorlevel 1 exit /b 0
+
+:open_default_browser
+start "" "%URL%"
+exit /b 0
+
+:try_app_path
+if not exist "%~1" exit /b 1
+start "" "%~1" --app="%URL%"
+exit /b 0
+
+:try_app_command
+where "%~1" >nul 2>nul || exit /b 1
+start "" "%~1" --app="%URL%"
+exit /b 0

--- a/packages/ema-dist/src/templates/open-webui.sh
+++ b/packages/ema-dist/src/templates/open-webui.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+URL="${1:?URL is required}"
+MODE="${2:-webview}"
+NODE_BIN="${3:-node}"
+
+if [ "$MODE" = "none" ]; then
+  exit 0
+fi
+
+wait_for_webui() {
+  "$NODE_BIN" - "$URL" <<'NODE'
+const url = process.argv[2];
+const deadline = Date.now() + 30000;
+
+async function sleep(ms) {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+while (Date.now() < deadline) {
+  try {
+    const response = await fetch(url, { signal: AbortSignal.timeout(1000) });
+    if (response.status < 500) {
+      process.exit(0);
+    }
+  } catch {
+    // Keep waiting until the server starts accepting connections.
+  }
+  await sleep(500);
+}
+
+process.exit(1);
+NODE
+}
+
+open_default_browser() {
+  case "$(uname -s)" in
+    Darwin)
+      open "$URL" >/dev/null 2>&1 &
+      return 0
+      ;;
+  esac
+
+  if command -v xdg-open >/dev/null 2>&1; then
+    xdg-open "$URL" >/dev/null 2>&1 &
+    return 0
+  fi
+  if command -v gio >/dev/null 2>&1; then
+    gio open "$URL" >/dev/null 2>&1 &
+    return 0
+  fi
+  echo "No default browser opener was found. Open $URL manually." >&2
+}
+
+open_webview_window() {
+  case "$(uname -s)" in
+    Darwin)
+      for app in "Microsoft Edge" "Google Chrome" "Chromium" "Brave Browser"; do
+        if open -Ra "$app" >/dev/null 2>&1; then
+          open -na "$app" --args --app="$URL" >/dev/null 2>&1 &
+          return 0
+        fi
+      done
+      ;;
+    *)
+      for command in microsoft-edge-stable microsoft-edge msedge google-chrome-stable google-chrome chromium chromium-browser brave-browser; do
+        if command -v "$command" >/dev/null 2>&1; then
+          "$command" --app="$URL" >/dev/null 2>&1 &
+          return 0
+        fi
+      done
+      ;;
+  esac
+
+  open_default_browser
+}
+
+wait_for_webui || exit 0
+case "$MODE" in
+  browser)
+    open_default_browser
+    ;;
+  webview|"")
+    open_webview_window
+    ;;
+  *)
+    echo "Unknown EMA_OPEN_MODE '$MODE'; falling back to webview." >&2
+    open_webview_window
+    ;;
+esac

--- a/packages/ema-dist/src/templates/start.cmd
+++ b/packages/ema-dist/src/templates/start.cmd
@@ -1,0 +1,52 @@
+@echo off
+setlocal
+set "APP_ROOT=%~dp0"
+if exist "%APP_ROOT%ema-runtime.cmd" call "%APP_ROOT%ema-runtime.cmd"
+
+set "SERVER_JS=%APP_ROOT%{{serverRelativePath}}"
+if not defined EMA_DATA_ROOT set "EMA_DATA_ROOT=%APP_ROOT%.ema"
+if not defined EMA_HOST set "EMA_HOST=127.0.0.1"
+if not defined EMA_PORT set "EMA_PORT=3000"
+if not defined EMA_MONGO_PORT set "EMA_MONGO_PORT=27017"
+if not defined EMA_OPEN_MODE set "EMA_OPEN_MODE=webview"
+
+set "NODE_BIN=%EMA_NODE_PATH%"
+if not defined NODE_BIN if exist "%APP_ROOT%portables\node\node.exe" set "NODE_BIN=%APP_ROOT%portables\node\node.exe"
+if not defined NODE_BIN for %%I in (node.exe) do set "NODE_BIN=%%~$PATH:I"
+if not defined NODE_BIN (
+  echo Node.js was not found. Run configure.cmd or put node on PATH.
+  exit /b 1
+)
+
+if not exist "%EMA_DATA_ROOT%\mongodb" mkdir "%EMA_DATA_ROOT%\mongodb"
+if not exist "%EMA_DATA_ROOT%\logs" mkdir "%EMA_DATA_ROOT%\logs"
+if not exist "%EMA_DATA_ROOT%\workspace" mkdir "%EMA_DATA_ROOT%\workspace"
+
+if not defined EMA_MONGO_URI (
+  set "MONGO_BIN=%EMA_MONGO_PATH%"
+  if not defined MONGO_BIN if exist "%APP_ROOT%portables\mongodb\bin\mongod.exe" set "MONGO_BIN=%APP_ROOT%portables\mongodb\bin\mongod.exe"
+  if not defined MONGO_BIN for %%I in (mongod.exe) do set "MONGO_BIN=%%~$PATH:I"
+  if not defined MONGO_BIN (
+    echo MongoDB was not found. Run configure.cmd, set EMA_MONGO_URI, or put mongod on PATH.
+    exit /b 1
+  )
+  set "EMA_MONGO_URI=mongodb://127.0.0.1:%EMA_MONGO_PORT%/"
+  start "EMA MongoDB" /B "%MONGO_BIN%" --dbpath "%EMA_DATA_ROOT%\mongodb" --port "%EMA_MONGO_PORT%" --bind_ip 127.0.0.1 --logpath "%EMA_DATA_ROOT%\logs\mongodb.log"
+)
+
+set "HOSTNAME=%EMA_HOST%"
+set "PORT=%EMA_PORT%"
+set "EMA_SERVER_MODE=prod"
+set "EMA_SERVER_MONGO_KIND=remote"
+set "EMA_SERVER_MONGO_DB=ema"
+set "EMA_SERVER_DATA_ROOT=%EMA_DATA_ROOT%"
+set "EMA_SERVER_MONGO_URI=%EMA_MONGO_URI%"
+set "EMA_WEBUI_URL=http://%EMA_HOST%:%EMA_PORT%/"
+
+if /I not "%EMA_OPEN_MODE%"=="none" (
+  start "" /B "%APP_ROOT%open-webui.cmd" "%EMA_WEBUI_URL%" "%EMA_OPEN_MODE%" "%NODE_BIN%"
+)
+
+echo EverMemoryArchive is starting at %EMA_WEBUI_URL%
+"%NODE_BIN%" "%SERVER_JS%"
+endlocal

--- a/packages/ema-dist/src/templates/start.sh
+++ b/packages/ema-dist/src/templates/start.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [ -f "$APP_ROOT/ema-runtime.sh" ]; then
+  # shellcheck disable=SC1091
+  . "$APP_ROOT/ema-runtime.sh"
+fi
+
+SERVER_JS="$APP_ROOT/{{serverRelativePath}}"
+DATA_ROOT="${EMA_DATA_ROOT:-$APP_ROOT/.ema}"
+HOST="${EMA_HOST:-127.0.0.1}"
+PORT="${EMA_PORT:-3000}"
+MONGO_PORT="${EMA_MONGO_PORT:-27017}"
+OPEN_MODE="${EMA_OPEN_MODE:-webview}"
+NODE_BIN="${EMA_NODE_PATH:-}"
+MONGO_BIN="${EMA_MONGO_PATH:-}"
+
+if [ -z "$NODE_BIN" ]; then
+  if [ -x "$APP_ROOT/portables/node/bin/node" ]; then
+    NODE_BIN="$APP_ROOT/portables/node/bin/node"
+  else
+    NODE_BIN="$(command -v node || true)"
+  fi
+fi
+
+if [ -z "$NODE_BIN" ]; then
+  echo "Node.js was not found. Run configure.sh or put node on PATH." >&2
+  exit 1
+fi
+
+mkdir -p "$DATA_ROOT/mongodb" "$DATA_ROOT/logs" "$DATA_ROOT/workspace"
+
+MONGO_URI="${EMA_MONGO_URI:-}"
+MONGO_PID=""
+if [ -z "$MONGO_URI" ]; then
+  if [ -z "$MONGO_BIN" ]; then
+    if [ -x "$APP_ROOT/portables/mongodb/bin/mongod" ]; then
+      MONGO_BIN="$APP_ROOT/portables/mongodb/bin/mongod"
+    else
+      MONGO_BIN="$(command -v mongod || true)"
+    fi
+  fi
+  if [ -z "$MONGO_BIN" ]; then
+    echo "MongoDB was not found. Run configure.sh, set EMA_MONGO_URI, or put mongod on PATH." >&2
+    exit 1
+  fi
+  MONGO_URI="mongodb://127.0.0.1:$MONGO_PORT/"
+  "$MONGO_BIN" --dbpath "$DATA_ROOT/mongodb" --port "$MONGO_PORT" --bind_ip 127.0.0.1 --logpath "$DATA_ROOT/logs/mongodb.log" &
+  MONGO_PID="$!"
+fi
+
+cleanup() {
+  if [ -n "$MONGO_PID" ]; then
+    kill "$MONGO_PID" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT INT TERM
+
+export HOSTNAME="$HOST"
+export PORT="$PORT"
+export EMA_SERVER_MODE=prod
+export EMA_SERVER_MONGO_KIND=remote
+export EMA_SERVER_MONGO_URI="$MONGO_URI"
+export EMA_SERVER_MONGO_DB="${EMA_MONGO_DB:-ema}"
+export EMA_SERVER_DATA_ROOT="$DATA_ROOT"
+
+WEBUI_URL="http://$HOST:$PORT/"
+if [ "$OPEN_MODE" != "none" ]; then
+  "$APP_ROOT/open-webui.sh" "$WEBUI_URL" "$OPEN_MODE" "$NODE_BIN" &
+fi
+
+echo "EverMemoryArchive is starting at $WEBUI_URL"
+"$NODE_BIN" "$SERVER_JS"

--- a/packages/ema-dist/tsconfig.json
+++ b/packages/ema-dist/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "verbatimModuleSyntax": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/ema-webui/next.config.ts
+++ b/packages/ema-webui/next.config.ts
@@ -22,6 +22,8 @@ function readWorkspaceVersion() {
 }
 
 const nextConfig: NextConfig = {
+  output: "standalone",
+  outputFileTracingRoot: workspaceRoot,
   transpilePackages: ["ema"],
   env: {
     NEXT_PUBLIC_EMA_VERSION: readWorkspaceVersion(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,8 @@ importers:
         specifier: ^0.2.6
         version: 0.2.6
 
+  packages/ema-dist: {}
+
   packages/ema-webui:
     dependencies:
       '@lancedb/lancedb':


### PR DESCRIPTION
## Summary
- add the `ema-dist` package for revisioning, portable dependency downloads, app staging, archives, and installer generation
- add distribution templates for launch/configuration/install flows across supported platforms
- add the Distribution Packages workflow for dev/preview/main/tag builds and wire package scripts for dist commands

## Testing
- `git diff --check origin/dev...HEAD`
- `pnpm --filter ema-dist run revision`