### PR TITLE
fix: make webui startup work on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,9 @@
   },
   "packageManager": "pnpm@10.16.1",
   "devDependencies": {
+    "@types/cross-spawn": "^6.0.6",
     "@types/node": "^20.11.17",
+    "cross-spawn": "^7.0.6",
     "prettier": "^3.7.4",
     "tsx": "^4.7.1",
     "typedoc": "^0.28.15",

--- a/packages/ema/src/prompt/loader.ts
+++ b/packages/ema/src/prompt/loader.ts
@@ -1,11 +1,9 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 
-const TEMPLATE_DIR = path.resolve(
-  path.dirname(fileURLToPath(import.meta.url)),
-  "templates",
-);
+import { resolveEmaSourcePath } from "../shared/package_path";
+
+const TEMPLATE_DIR = resolveEmaSourcePath("prompt", "templates");
 const templateCache = new Map<string, string>();
 
 /**

--- a/packages/ema/src/shared/package_path.ts
+++ b/packages/ema/src/shared/package_path.ts
@@ -1,0 +1,34 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+export function resolveEmaSourcePath(...segments: string[]): string {
+  const workspaceRoot = resolveWorkspaceRoot();
+  if (workspaceRoot) {
+    return path.join(workspaceRoot, "packages", "ema", "src", ...segments);
+  }
+  return path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "..",
+    ...segments,
+  );
+}
+
+function resolveWorkspaceRoot(): string | null {
+  const configuredRoot = process.env.EMA_WORKSPACE_ROOT?.trim();
+  if (configuredRoot) {
+    return path.resolve(configuredRoot);
+  }
+
+  let current = path.dirname(fileURLToPath(import.meta.url));
+  for (;;) {
+    if (fs.existsSync(path.join(current, "pnpm-workspace.yaml"))) {
+      return current;
+    }
+    const parent = path.dirname(current);
+    if (parent === current) {
+      return null;
+    }
+    current = parent;
+  }
+}

--- a/packages/ema/src/skills/base.ts
+++ b/packages/ema/src/skills/base.ts
@@ -1,8 +1,8 @@
 import fs from "node:fs";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 import type { ToolResult, ToolContext } from "../tools/base";
 import { Logger } from "../shared/logger";
+import { resolveEmaSourcePath } from "../shared/package_path";
 
 /** Skill name -> Skill instance registry. */
 export type SkillRegistry = Record<string, Skill>;
@@ -125,7 +125,7 @@ function stripYamlFrontmatter(markdown: string): {
  * @returns Registry keyed by skill name.
  */
 export async function loadSkills(
-  skillsDir: string = path.dirname(fileURLToPath(import.meta.url)),
+  skillsDir: string = resolveEmaSourcePath("skills"),
 ): Promise<SkillRegistry> {
   const logger = Logger.create({
     name: "skills",
@@ -139,7 +139,7 @@ export async function loadSkills(
     throw new Error(`Skills directory does not exist: ${skillsDir}`);
   }
 
-  const baseDir = path.dirname(fileURLToPath(import.meta.url));
+  const baseDir = resolveEmaSourcePath("skills");
   const skillsDirAbs = path.resolve(skillsDir);
   let skillsRel = path.relative(baseDir, skillsDirAbs) || ".";
   if (!skillsRel.startsWith(".")) {

--- a/packages/ema/src/skills/sticker-skill/pack.ts
+++ b/packages/ema/src/skills/sticker-skill/pack.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+
+import { resolveEmaSourcePath } from "../../shared/package_path";
 
 /**
  * One sticker entry inside one sticker pack.
@@ -54,8 +55,9 @@ export interface ResolvedStickerPack extends StickerPackDefinition {
   stickers: ResolvedStickerDefinition[];
 }
 
-const STICKER_ASSETS_DIR = path.resolve(
-  path.dirname(fileURLToPath(import.meta.url)),
+const STICKER_ASSETS_DIR = resolveEmaSourcePath(
+  "skills",
+  "sticker-skill",
   "assets",
 );
 

--- a/packages/ema/src/skills/sticker-skill/utils.ts
+++ b/packages/ema/src/skills/sticker-skill/utils.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 import type { ImageMIME, InlineDataItem } from "../../shared/schema";
+import { resolveEmaSourcePath } from "../../shared/package_path";
 import {
   getStickerById,
   getStickerInPack,
@@ -10,8 +10,9 @@ import {
 } from "./pack";
 
 const COLLECTION_PACK_NAME = "收藏";
-const STICKER_ASSETS_DIR = path.resolve(
-  path.dirname(fileURLToPath(import.meta.url)),
+const STICKER_ASSETS_DIR = resolveEmaSourcePath(
+  "skills",
+  "sticker-skill",
   "assets",
 );
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,9 +13,15 @@ importers:
 
   .:
     devDependencies:
+      '@types/cross-spawn':
+        specifier: ^6.0.6
+        version: 6.0.6
       '@types/node':
         specifier: ^20.11.17
         version: 20.19.27
+      cross-spawn:
+        specifier: ^7.0.6
+        version: 7.0.6
       prettier:
         specifier: ^3.7.4
         version: 3.7.4
@@ -1505,6 +1511,9 @@ packages:
 
   '@types/command-line-usage@5.0.4':
     resolution: {integrity: sha512-BwR5KP3Es/CSht0xqBcUXS3qCAUVXwpRKsV2+arxeb65atasuXG9LykC9Ab10Cw3s2raH92ZqOeILaQbsB2ACg==}
+
+  '@types/cross-spawn@6.0.6':
+    resolution: {integrity: sha512-fXRhhUkG4H3TQk5dBhQ7m/JDdSNHKwR2BBia62lhwEIq9xGiQKLxd6LymNhn47SjXhsUEPmxi+PKw2OkW4LLjA==}
 
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
@@ -6125,6 +6134,10 @@ snapshots:
   '@types/command-line-args@5.2.3': {}
 
   '@types/command-line-usage@5.0.4': {}
+
+  '@types/cross-spawn@6.0.6':
+    dependencies:
+      '@types/node': 20.19.27
 
   '@types/deep-eql@4.0.2': {}
 

--- a/scripts/webui.ts
+++ b/scripts/webui.ts
@@ -1,8 +1,8 @@
-import { spawn } from "node:child_process";
 import { mkdirSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { parseArgs } from "node:util";
+import spawn from "cross-spawn";
 
 const MONGO_DB_NAME = "ema";
 
@@ -83,9 +83,10 @@ function main() {
     EMA_SERVER_MONGO_URI: mongoUri,
     EMA_SERVER_MONGO_DB: MONGO_DB_NAME,
     EMA_SERVER_DATA_ROOT: dataRoot,
+    EMA_WORKSPACE_ROOT: repoRoot,
   };
 
-  const child = spawn(pnpmCommand(), nextArgs, {
+  const child = spawn("pnpm", nextArgs, {
     cwd: repoRoot,
     env,
     stdio: "inherit",
@@ -103,10 +104,6 @@ function main() {
 function fail(message: string): never {
   process.stderr.write(`EMA WebUI startup error: ${message}\n\n${HELP}`);
   process.exit(1);
-}
-
-function pnpmCommand() {
-  return process.platform === "win32" ? "pnpm.cmd" : "pnpm";
 }
 
 main();


### PR DESCRIPTION
This pull request refactors how file paths are resolved in the EMA codebase to make the code more robust and portable, especially across different environments and when running from various locations. A new utility function, `resolveEmaSourcePath`, is introduced to consistently resolve source paths relative to the workspace root, and its usage replaces previous ad-hoc path resolution logic throughout the codebase. Additionally, the PR improves the reliability of spawning child processes in scripts by switching to `cross-spawn`.

**Verified that all features work as expected on Windows 11 25H2, Ubuntu 22.04.5 LTS, and macOS 15.5 Sequoia.**

Key improvements include:

**Path Resolution Refactor:**

* Introduced `resolveEmaSourcePath` in `packages/ema/src/shared/package_path.ts`, which resolves paths relative to the workspace root, falling back to the current file location if needed. It also detects the workspace root via the `EMA_WORKSPACE_ROOT` environment variable or by searching for `pnpm-workspace.yaml`.
* Updated `packages/ema/src/prompt/loader.ts`, `packages/ema/src/skills/base.ts`, `packages/ema/src/skills/sticker-skill/pack.ts`, and `packages/ema/src/skills/sticker-skill/utils.ts` to use `resolveEmaSourcePath` for resolving template and asset directories, replacing previous logic based on `fileURLToPath` and manual path manipulation. [[1]](diffhunk://#diff-21e1c390398eff2a20a754879d96b84572e1dc1d237ef5aa18e676b997132a6aL3-R6) [[2]](diffhunk://#diff-6ea2b32442cd6196c721d48edb1cf7e2dfa81f03d338988bc2a9bab2a255823dL3-R5) [[3]](diffhunk://#diff-6ea2b32442cd6196c721d48edb1cf7e2dfa81f03d338988bc2a9bab2a255823dL128-R128) [[4]](diffhunk://#diff-6ea2b32442cd6196c721d48edb1cf7e2dfa81f03d338988bc2a9bab2a255823dL142-R142) [[5]](diffhunk://#diff-2488a8a2b26c4041c80a467c20da4f5de551e2185b32e2c8dd6de4ab10cd1265L3-R4) [[6]](diffhunk://#diff-2488a8a2b26c4041c80a467c20da4f5de551e2185b32e2c8dd6de4ab10cd1265L57-R60) [[7]](diffhunk://#diff-7877b48059dc7110713c77c606fb7bd936436945a77206a78ca8ffa24b494ed6L3-R4) [[8]](diffhunk://#diff-7877b48059dc7110713c77c606fb7bd936436945a77206a78ca8ffa24b494ed6L13-R15)

**Script and Dependency Improvements:**

* Refactored `scripts/webui.ts` to use `cross-spawn` instead of the native `child_process.spawn`, improving cross-platform compatibility. The script now also sets the `EMA_WORKSPACE_ROOT` environment variable when spawning child processes. [[1]](diffhunk://#diff-2b903e60f90490705af715a12851ebee089eb6ff52cb6402870aa9ef7aa78246L1-R5) [[2]](diffhunk://#diff-2b903e60f90490705af715a12851ebee089eb6ff52cb6402870aa9ef7aa78246R86-R89) [[3]](diffhunk://#diff-2b903e60f90490705af715a12851ebee089eb6ff52cb6402870aa9ef7aa78246L108-L111)
* Added `cross-spawn` and its type definitions to `package.json` and `pnpm-lock.yaml` as development dependencies. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R29-R31) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR16-R24) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1506-R1508) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR6113-R6116)