### PR TITLE
feat: add release automation and checksum artifacts

### DIFF
--- a/.agents/skills/ema-release/SKILL.md
+++ b/.agents/skills/ema-release/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: ema-release
+description: Use when preparing or validating an EverMemoryArchive release, including version preflight, release version updates, CHANGELOG.md generation, parse-changelog release notes, distribution artifact checksums, tag-release CI behavior, and draft/publish handoff. Trigger for requests like "prepare EMA release", "发版", "release v1.0.0-beta.2", "generate changelog", or "draft release notes".
+---
+
+# EMA Release
+
+Use this workflow for EverMemoryArchive release preparation. Keep the work local until the maintainer explicitly approves external side effects such as pushing tags, publishing GitHub releases, or marking a draft PR ready.
+
+## Workflow
+
+1. Normalize the target version.
+   - Accept `v1.0.0-beta.1` or `1.0.0-beta.1`.
+   - Use the normalized version without `v` for source files.
+   - Use the tag form with `v` for changelog, release notes, and git tag commands.
+
+2. Inspect readiness before editing.
+
+   ```bash
+   node scripts/release-preflight.mjs <version> --json
+   ```
+
+   Report the target tag, release type, current branch, changelog status, pending version updates, and generated follow-up commands.
+
+3. Apply local release preparation when asked.
+   - Update version strings:
+
+     ```bash
+     node scripts/release-preflight.mjs <version> --write
+     ```
+
+   - Generate or refresh the root changelog:
+
+     ```bash
+     node scripts/generate-changelog.mjs <version> --write
+     ```
+
+   - Re-run preflight after edits and call out any remaining pending updates.
+
+4. Validate locally.
+   - Fast checks:
+
+     ```bash
+     pnpm format:check
+     pnpm --filter ema-dist exec tsc --noEmit -p tsconfig.json
+     node scripts/release-preflight.mjs <version> --json
+     parse-changelog ./CHANGELOG.md
+     ```
+
+5. Generate release notes from changelog and artifacts.
+
+   ```bash
+   node scripts/draft-release.mjs <version> --artifacts dist/release --output dist/release-notes.md
+   ```
+
+   `draft-release` depends on external `parse-changelog`; install it before running locally if missing.
+
+6. Build distribution artifacts only when feasible for the current platform.
+
+   ```bash
+   pnpm --filter ema-webui build
+   pnpm --filter ema-dist run build -- --platform <platform-id>
+   ```
+
+   Use `pnpm --filter ema-dist run list-platforms` to list supported platform ids.
+
+7. Stop before external release side effects.
+   - Do not run `git tag`, `git push --tags`, `gh release create`, `gh release edit`, `gh release upload`, or equivalent publishing commands unless the maintainer explicitly approves that exact action.
+   - When asking for approval, show the exact command and whether it will create/update a public GitHub release.
+
+## Guardrails
+
+- Keep root `package.json`, `packages/ema/package.json`, `packages/ema-webui/package.json`, `packages/ema-dist/Cargo.toml`, and `packages/ema-dist/Cargo.lock` release versions aligned through `release-preflight`.
+- Keep root `CHANGELOG.md` in the format consumed by `parse-changelog`: `## vX.Y.Z - [YYYY-MM-DD]`, topic headings, bullet items, and a `**Full Changelog**` line.
+- Use `gh api repos/<owner>/<repo>/releases/generate-notes` through `scripts/generate-changelog.mjs` for changelog candidates.
+- Distribution archives and installers should have sibling `.sha256` files; the dist scripts create them automatically.
+- Tag CI creates or updates GitHub releases from `dist.yml`; release notes are generated with `scripts/draft-release.mjs`.
+- Treat `linux-armhf` and `alpine-x64` portable packages as unsupported unless `--include-unsupported-portable` is intentionally passed.

--- a/.agents/skills/ema-release/agents/openai.yaml
+++ b/.agents/skills/ema-release/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "EMA Release"
+  short_description: "Prepare EverMemoryArchive releases."
+  default_prompt: "Prepare an EverMemoryArchive release using the repository release scripts."

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -177,7 +177,9 @@ jobs:
         with:
           name: ema-${{ matrix.platform }}-minimal-zip
           if-no-files-found: error
-          path: dist/${{ matrix.platform }}/ema-${{ matrix.platform }}-minimal-*.zip
+          path: |
+            dist/${{ matrix.platform }}/ema-${{ matrix.platform }}-minimal-*.zip
+            dist/${{ matrix.platform }}/ema-${{ matrix.platform }}-minimal-*.zip.sha256
 
       - name: Build minimal 7z package
         run: pnpm --filter ema-dist run pack -- --platform ${{ matrix.platform }} --kind minimal --format 7z
@@ -187,7 +189,9 @@ jobs:
         with:
           name: ema-${{ matrix.platform }}-minimal-7z
           if-no-files-found: error
-          path: dist/${{ matrix.platform }}/ema-${{ matrix.platform }}-minimal-*.7z
+          path: |
+            dist/${{ matrix.platform }}/ema-${{ matrix.platform }}-minimal-*.7z
+            dist/${{ matrix.platform }}/ema-${{ matrix.platform }}-minimal-*.7z.sha256
 
       - name: Stage portable package
         run: pnpm --filter ema-dist run stage -- --platform ${{ matrix.platform }} --kind portable
@@ -205,7 +209,9 @@ jobs:
         with:
           name: ema-${{ matrix.platform }}-portable-zip
           if-no-files-found: error
-          path: dist/${{ matrix.platform }}/ema-${{ matrix.platform }}-portable-*.zip
+          path: |
+            dist/${{ matrix.platform }}/ema-${{ matrix.platform }}-portable-*.zip
+            dist/${{ matrix.platform }}/ema-${{ matrix.platform }}-portable-*.zip.sha256
 
       - name: Build portable 7z package
         if: ${{ matrix.platform != 'linux-armhf' && matrix.platform != 'alpine-x64' }}
@@ -217,7 +223,11 @@ jobs:
         with:
           name: ema-${{ matrix.platform }}-portable-7z
           if-no-files-found: error
-          path: dist/${{ matrix.platform }}/ema-${{ matrix.platform }}-portable-*.7z
+          path: |
+            dist/${{ matrix.platform }}/ema-${{ matrix.platform }}-portable-*.7z
+            dist/${{ matrix.platform }}/ema-${{ matrix.platform }}-portable-*.7z.sha256
+            !dist/${{ matrix.platform }}/ema-${{ matrix.platform }}-portable-debug-symbols-*.7z
+            !dist/${{ matrix.platform }}/ema-${{ matrix.platform }}-portable-debug-symbols-*.7z.sha256
 
       - name: Build portable installer
         if: ${{ matrix.platform != 'linux-armhf' && matrix.platform != 'alpine-x64' }}
@@ -231,6 +241,16 @@ jobs:
           if-no-files-found: error
           path: dist/${{ matrix.platform }}/ema-${{ matrix.platform }}-portable-*-installer.*
 
+      - name: Upload portable debug symbols artifact
+        if: ${{ matrix.platform != 'linux-armhf' && matrix.platform != 'alpine-x64' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ema-${{ matrix.platform }}-portable-debug-symbols
+          if-no-files-found: ignore
+          path: |
+            dist/${{ matrix.platform }}/ema-${{ matrix.platform }}-portable-debug-symbols-*.7z
+            dist/${{ matrix.platform }}/ema-${{ matrix.platform }}-portable-debug-symbols-*.7z.sha256
+
       - name: Write portable skipped note
         if: ${{ matrix.platform == 'linux-armhf' || matrix.platform == 'alpine-x64' }}
         run: pnpm --filter ema-dist run skip-note -- --platform ${{ matrix.platform }}
@@ -242,3 +262,48 @@ jobs:
           name: ema-${{ matrix.platform }}-portable-skipped
           if-no-files-found: error
           path: dist/${{ matrix.platform }}/*.SKIPPED.txt
+
+  release:
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: ema-*
+          path: artifacts
+          merge-multiple: true
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install parse-changelog
+        uses: taiki-e/install-action@parse-changelog
+
+      - name: Generate release notes
+        run: node scripts/draft-release.mjs "$GITHUB_REF_NAME" --artifacts artifacts --output dist/release-notes.md
+
+      - name: Publish GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          prerelease_flag=""
+          if [[ "$GITHUB_REF_NAME" == *-* ]]; then
+            prerelease_flag="--prerelease"
+          fi
+
+          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            gh release upload "$GITHUB_REF_NAME" artifacts/* --clobber
+            gh release edit "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" --notes-file dist/release-notes.md $prerelease_flag
+          else
+            gh release create "$GITHUB_REF_NAME" artifacts/* --title "$GITHUB_REF_NAME" --notes-file dist/release-notes.md $prerelease_flag
+          fi

--- a/package.json
+++ b/package.json
@@ -27,6 +27,10 @@
     "dist:pack": "pnpm --filter ema-dist run pack",
     "dist:installers": "pnpm --filter ema-dist run installers",
     "dist:build": "pnpm --filter ema-dist run build",
+    "dist:list-platforms": "pnpm --filter ema-dist run list-platforms",
+    "release:preflight": "node scripts/release-preflight.mjs",
+    "release:changelog": "node scripts/generate-changelog.mjs",
+    "draft-release": "node scripts/draft-release.mjs",
     "format": "prettier --write \"{packages,scripts}/**/*.{js,jsx,ts,tsx,json,css}\"",
     "format:check": "prettier --check \"{packages,scripts}/**/*.{js,jsx,ts,tsx,json,css}\""
   },

--- a/packages/ema-dist/README.md
+++ b/packages/ema-dist/README.md
@@ -48,6 +48,8 @@ ema-$platform-minimal-$revision.zip
 ema-$platform-portable-$revision.zip
 ```
 
+Each archive and installer is accompanied by a sibling `.sha256` file.
+
 The platform ids are:
 
 ```text

--- a/packages/ema-dist/package.json
+++ b/packages/ema-dist/package.json
@@ -9,6 +9,7 @@
     "pack": "node --import tsx --import ./src/raw-import-loader.mjs src/cli.ts pack",
     "installers": "node --import tsx --import ./src/raw-import-loader.mjs src/cli.ts installers",
     "skip-note": "node --import tsx --import ./src/raw-import-loader.mjs src/cli.ts skip-note",
+    "list-platforms": "node --import tsx --import ./src/raw-import-loader.mjs src/cli.ts list-platforms",
     "build": "node --import tsx --import ./src/raw-import-loader.mjs src/cli.ts build"
   },
   "dependencies": {

--- a/packages/ema-dist/src/archive.ts
+++ b/packages/ema-dist/src/archive.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { writeSha256File } from "./checksums";
 import { commandExists, execFile } from "./shell";
 import { packageFileName, platformDistRoot } from "./paths";
 import type { PackageKind, Platform } from "./platforms";
@@ -90,6 +91,7 @@ async function createArchiveFiles(
     await execFile(sevenZip, ["a", `-t${format}`, outputs[index], rootName], {
       cwd: parent,
     });
+    await writeSha256File(outputs[index]);
   }
 
   return [...outputs];

--- a/packages/ema-dist/src/checksums.ts
+++ b/packages/ema-dist/src/checksums.ts
@@ -1,0 +1,30 @@
+import { createHash } from "node:crypto";
+import { createReadStream } from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+export async function sha256File(filePath: string): Promise<string> {
+  const hash = createHash("sha256");
+  const stream = createReadStream(filePath);
+
+  await new Promise<void>((resolve, reject) => {
+    stream.on("data", (chunk) => {
+      hash.update(chunk);
+    });
+    stream.on("error", reject);
+    stream.on("end", resolve);
+  });
+
+  return hash.digest("hex");
+}
+
+export async function writeSha256File(filePath: string): Promise<string> {
+  const digest = await sha256File(filePath);
+  const checksumPath = `${filePath}.sha256`;
+  await fs.writeFile(
+    checksumPath,
+    `${digest}  ${path.basename(filePath)}\n`,
+    "utf8",
+  );
+  return checksumPath;
+}

--- a/packages/ema-dist/src/installer.ts
+++ b/packages/ema-dist/src/installer.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { removeDanglingSymlinks } from "./archive";
+import { writeSha256File } from "./checksums";
 import { installerFileName, platformDistRoot, stageRoot } from "./paths";
 import type { PackageKind, Platform } from "./platforms";
 import { buildRustBinary } from "./rust";
@@ -30,5 +31,6 @@ export async function createSelfInstaller(
   if (platform.os !== "win32") {
     await fs.chmod(outputPath, 0o755);
   }
+  await writeSha256File(outputPath);
   return outputPath;
 }

--- a/scripts/draft-release.mjs
+++ b/scripts/draft-release.mjs
@@ -1,0 +1,249 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+
+const args = process.argv.slice(2);
+let targetArg = "";
+let artifactsDir = "dist/release";
+let changelogPath = "CHANGELOG.md";
+let outputPath = "dist/release-notes.md";
+let outputJson = false;
+
+for (let index = 0; index < args.length; index += 1) {
+  const arg = args[index];
+  if (arg === "--artifacts") {
+    artifactsDir = args[index + 1] ?? "";
+    if (!artifactsDir) {
+      usage("--artifacts requires a directory");
+    }
+    index += 1;
+    continue;
+  }
+
+  if (arg === "--changelog") {
+    changelogPath = args[index + 1] ?? "";
+    if (!changelogPath) {
+      usage("--changelog requires a file path");
+    }
+    index += 1;
+    continue;
+  }
+
+  if (arg === "--output") {
+    outputPath = args[index + 1] ?? "";
+    if (!outputPath) {
+      usage("--output requires a file path");
+    }
+    index += 1;
+    continue;
+  }
+
+  if (arg === "--json") {
+    outputJson = true;
+    continue;
+  }
+
+  if (!targetArg) {
+    targetArg = arg;
+    continue;
+  }
+
+  usage(`Unexpected argument: ${arg}`);
+}
+
+if (!targetArg) {
+  usage("Missing target version");
+}
+
+const version = normalizeVersion(targetArg);
+validateVersion(version);
+
+const tag = `v${version}`;
+const packageVersion = JSON.parse(
+  fs.readFileSync("package.json", "utf8"),
+).version;
+
+if (packageVersion !== version) {
+  throw new Error(
+    `package.json version (${packageVersion}) does not match release version (${version})`,
+  );
+}
+
+const repository = githubRepository();
+const changelog = runText("parse-changelog", [changelogPath]);
+const artifacts = listArtifacts(artifactsDir);
+const artifactTable = renderArtifactTable(artifacts, repository, tag);
+const notes = `${changelog.trimEnd()}\n\n${artifactTable}\n`;
+
+fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+fs.writeFileSync(outputPath, notes, "utf8");
+
+if (process.env.GITHUB_OUTPUT) {
+  fs.appendFileSync(process.env.GITHUB_OUTPUT, `tag=${tag}\n`);
+}
+
+if (outputJson) {
+  process.stdout.write(
+    `${JSON.stringify(
+      {
+        version,
+        tag,
+        changelogPath,
+        artifactsDir,
+        outputPath,
+        artifactCount: artifacts.length,
+      },
+      null,
+      2,
+    )}\n`,
+  );
+} else {
+  console.log(`Wrote ${outputPath}`);
+}
+
+function usage(message) {
+  if (message) {
+    console.error(message);
+  }
+  console.error(
+    [
+      "Usage:",
+      "  node scripts/draft-release.mjs <version> [--artifacts <dir>]",
+      "    [--changelog <file>] [--output <file>] [--json]",
+    ].join(" "),
+  );
+  process.exit(1);
+}
+
+function normalizeVersion(version) {
+  return version.startsWith("v") ? version.slice(1) : version;
+}
+
+function validateVersion(version) {
+  if (/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(version)) {
+    return;
+  }
+
+  usage(`Invalid semver version: ${version}`);
+}
+
+function renderArtifactTable(artifacts, repository, tag) {
+  if (artifacts.length === 0) {
+    return "## Artifacts\n\nNo release artifacts were found.\n";
+  }
+
+  const urlBase = `https://github.com/${repository}/releases/download/${tag}`;
+  const rows = artifacts.map((artifact) => {
+    const file = `[${artifact.name}](${urlBase}/${encodeURIComponent(artifact.name)})`;
+    const checksum = artifact.sha256 ? `\`${artifact.sha256}\`` : "";
+    return `| ${file} | ${checksum} |`;
+  });
+
+  return [
+    "## Artifacts",
+    "",
+    "| File | SHA-256 |",
+    "| ---- | ------- |",
+    ...rows,
+    "",
+  ].join("\n");
+}
+
+function listArtifacts(directory) {
+  if (!fs.existsSync(directory)) {
+    return [];
+  }
+
+  return listFiles(directory)
+    .filter((filePath) => isReleaseArtifact(filePath))
+    .map((filePath) => ({
+      path: filePath,
+      name: path.basename(filePath),
+      sha256: readChecksum(`${filePath}.sha256`),
+    }))
+    .sort((left, right) => left.name.localeCompare(right.name));
+}
+
+function listFiles(directory) {
+  const entries = fs.readdirSync(directory, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...listFiles(entryPath));
+      continue;
+    }
+    if (entry.isFile()) {
+      files.push(entryPath);
+    }
+  }
+
+  return files;
+}
+
+function isReleaseArtifact(filePath) {
+  const fileName = path.basename(filePath);
+  if (fileName.endsWith(".sha256")) {
+    return false;
+  }
+  if (fileName.endsWith(".SKIPPED.txt")) {
+    return true;
+  }
+  return /\.(?:7z|zip|exe|run|command)$/.test(fileName);
+}
+
+function readChecksum(filePath) {
+  if (!fs.existsSync(filePath)) {
+    return "";
+  }
+
+  const content = fs.readFileSync(filePath, "utf8").trim();
+  return content.split(/\s+/)[0] ?? "";
+}
+
+function githubRepository() {
+  if (process.env.GITHUB_REPOSITORY) {
+    return process.env.GITHUB_REPOSITORY;
+  }
+
+  const remote = readGitRemote();
+  const match = remote.match(/github\.com[:/]([^/]+\/[^/.]+)(?:\.git)?$/);
+  if (!match) {
+    throw new Error(`Could not infer GitHub repository from origin: ${remote}`);
+  }
+  return match[1];
+}
+
+function readGitRemote() {
+  try {
+    return execFileSync("git", ["remote", "get-url", "origin"], {
+      encoding: "utf8",
+    }).trim();
+  } catch (error) {
+    const stdout = error.stdout?.toString().trim();
+    if (stdout) {
+      return stdout;
+    }
+    throw error;
+  }
+}
+
+function runText(command, args) {
+  try {
+    return execFileSync(command, args, { encoding: "utf8" });
+  } catch (error) {
+    const stdout = error.stdout?.toString();
+    if (stdout) {
+      return stdout;
+    }
+    if (error.code === "ENOENT") {
+      throw new Error(
+        `${command} was not found. Install parse-changelog before drafting release notes.`,
+      );
+    }
+    throw error;
+  }
+}

--- a/scripts/generate-changelog.mjs
+++ b/scripts/generate-changelog.mjs
@@ -1,0 +1,433 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+
+const args = process.argv.slice(2);
+let targetArg = "";
+let outputJson = false;
+let write = false;
+let previousTag = "";
+let notesFile = "";
+
+for (let index = 0; index < args.length; index += 1) {
+  const arg = args[index];
+  if (arg === "--json") {
+    outputJson = true;
+    continue;
+  }
+
+  if (arg === "--write") {
+    write = true;
+    continue;
+  }
+
+  if (arg === "--previous-tag") {
+    previousTag = args[index + 1] ?? "";
+    if (!previousTag) {
+      usage("--previous-tag requires a tag");
+    }
+    index += 1;
+    continue;
+  }
+
+  if (arg === "--notes-file") {
+    notesFile = args[index + 1] ?? "";
+    if (!notesFile) {
+      usage("--notes-file requires a file path");
+    }
+    index += 1;
+    continue;
+  }
+
+  if (!targetArg) {
+    targetArg = arg;
+    continue;
+  }
+
+  usage(`Unexpected argument: ${arg}`);
+}
+
+if (!targetArg) {
+  usage("Missing target version");
+}
+
+const targetVersion = normalizeVersion(targetArg);
+validateVersion(targetVersion);
+
+const targetTag = `v${targetVersion}`;
+const repository = githubRepository();
+const generatedNotes = notesFile
+  ? fs.readFileSync(notesFile, "utf8")
+  : fetchGeneratedNotes(repository, targetTag, previousTag);
+const entry = renderEntry(targetVersion, generatedNotes, repository);
+const changelog = upsertChangelogEntry("CHANGELOG.md", targetVersion, entry);
+
+const result = {
+  targetVersion,
+  targetTag,
+  repository,
+  previousTag: previousTag || null,
+  itemCount: parseGeneratedItems(generatedNotes).length,
+  changelog,
+};
+
+if (write) {
+  fs.writeFileSync("CHANGELOG.md", changelog.content, "utf8");
+}
+
+if (outputJson) {
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+} else if (write) {
+  console.log(`Updated CHANGELOG.md for ${targetTag}`);
+} else {
+  process.stdout.write(changelog.content);
+}
+
+function usage(message) {
+  if (message) {
+    console.error(message);
+  }
+  console.error(
+    [
+      "Usage:",
+      "  node scripts/generate-changelog.mjs <version> [--previous-tag <tag>]",
+      "    [--notes-file <file>] [--write] [--json]",
+    ].join(" "),
+  );
+  process.exit(1);
+}
+
+function normalizeVersion(version) {
+  return version.startsWith("v") ? version.slice(1) : version;
+}
+
+function validateVersion(version) {
+  if (/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(version)) {
+    return;
+  }
+
+  usage(`Invalid semver version: ${version}`);
+}
+
+function githubRepository() {
+  if (process.env.GITHUB_REPOSITORY) {
+    return process.env.GITHUB_REPOSITORY;
+  }
+
+  const remote = readGitRemote();
+  const match = remote.match(/github\.com[:/]([^/]+\/[^/.]+)(?:\.git)?$/);
+  if (!match) {
+    throw new Error(`Could not infer GitHub repository from origin: ${remote}`);
+  }
+  return match[1];
+}
+
+function readGitRemote() {
+  try {
+    return execFileSync("git", ["remote", "get-url", "origin"], {
+      encoding: "utf8",
+    }).trim();
+  } catch (error) {
+    const stdout = error.stdout?.toString().trim();
+    if (stdout) {
+      return stdout;
+    }
+    throw error;
+  }
+}
+
+function fetchGeneratedNotes(repository, tagName, previousTagName) {
+  const args = [
+    "api",
+    `repos/${repository}/releases/generate-notes`,
+    "-f",
+    `tag_name=${tagName}`,
+  ];
+  if (previousTagName) {
+    args.push("-f", `previous_tag_name=${previousTagName}`);
+  }
+  args.push("--jq", ".body");
+
+  return execFileSync("gh", args, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+function renderEntry(version, notes, repository) {
+  const items = parseGeneratedItems(notes);
+  const grouped = groupItems(items);
+  const lines = [`## v${version} - [${today()}]`, ""];
+
+  for (const [section, sectionItems] of grouped) {
+    if (sectionItems.length === 0) {
+      continue;
+    }
+
+    lines.push(`### ${section}`, "");
+    for (const item of sectionItems) {
+      lines.push(`* ${formatItem(item)}`);
+    }
+    lines.push("");
+  }
+
+  const fullChangelog = fullChangelogLine(notes, version, repository);
+  lines.push(fullChangelog);
+  lines.push("");
+
+  return lines.join("\n");
+}
+
+function parseGeneratedItems(notes) {
+  return notes
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith("* "))
+    .filter((line) => !line.includes(" made their first contribution in "))
+    .map((line) => parseGeneratedItem(line.slice(2)));
+}
+
+function parseGeneratedItem(line) {
+  const match = line.match(/^(.*?) by (@[^\s]+) in (https:\/\/github\.com\/[^\s]+)$/);
+  if (!match) {
+    return {
+      raw: line,
+      title: line,
+      author: "",
+      url: "",
+      type: "",
+      scope: "",
+      subject: line,
+    };
+  }
+
+  const parsed = parseConventionalTitle(match[1]);
+  return {
+    raw: line,
+    title: match[1],
+    author: match[2],
+    url: match[3],
+    ...parsed,
+  };
+}
+
+function parseConventionalTitle(title) {
+  const match = title.match(/^([a-z]+)(?:\(([^)]+)\))?!?:\s*(.+)$/i);
+  if (!match) {
+    return {
+      type: "",
+      scope: "",
+      subject: title,
+    };
+  }
+
+  const nested = match[3].match(/^([a-z]+)(?:\(([^)]+)\))?!?:\s*(.+)$/i);
+  if (nested) {
+    return {
+      type: nested[1].toLowerCase(),
+      scope: nested[2] ?? match[2] ?? "",
+      subject: nested[3],
+    };
+  }
+
+  return {
+    type: match[1].toLowerCase(),
+    scope: match[2] ?? "",
+    subject: match[3],
+  };
+}
+
+function groupItems(items) {
+  const sections = new Map([
+    ["Core Runtime", []],
+    ["Memory and Data", []],
+    ["LLM and Skills", []],
+    ["WebUI", []],
+    ["Distribution", []],
+    ["CI and Documentation", []],
+    ["Misc", []],
+  ]);
+
+  for (const item of items) {
+    sections.get(sectionFor(item)).push(item);
+  }
+
+  return [...sections.entries()].filter(([, sectionItems]) => sectionItems.length > 0);
+}
+
+function sectionFor(item) {
+  const text = `${item.scope} ${item.subject}`.toLowerCase();
+
+  if (
+    /\b(dist|distribution|installer|portable|minimal|launcher|setup|pack|package|artifact|download|revision|node|rust|cargo|windows|linux|darwin|alpine|icon|favicon)\b/.test(
+      text,
+    )
+  ) {
+    return "Distribution";
+  }
+
+  if (
+    /\b(webui|web ui|dashboard|chat panel|sidebar|settings|next|react|css|ui|frontend|actor settings|create actor|setup page)\b/.test(
+      text,
+    )
+  ) {
+    return "WebUI";
+  }
+
+  if (
+    /\b(memory|lance|lancedb|mongo|mongodb|database|embedding|vector|long-term|short-term|checkpoint|trainer)\b/.test(
+      text,
+    )
+  ) {
+    return "Memory and Data";
+  }
+
+  if (
+    /\b(llm|openai|google|gemini|model|skill|prompt|tool|agent prompt|web search)\b/.test(
+      text,
+    )
+  ) {
+    return "LLM and Skills";
+  }
+
+  if (
+    /\b(actor|scheduler|controller|gateway|bus|server|runtime|channel|napcat|qq|conversation|session)\b/.test(
+      text,
+    )
+  ) {
+    return "Core Runtime";
+  }
+
+  if (
+    /\b(test|fixture|vitest|docs|documentation|readme|spec|ci|github actions|pnpm|build|format|lint|typescript|docker|deployment)\b/.test(
+      text,
+    )
+  ) {
+    return "CI and Documentation";
+  }
+
+  return "Misc";
+}
+
+function formatItem(item) {
+  const prefix = itemPrefix(item.type);
+  const subject = sentenceCase(cleanSubject(item.subject));
+  const author = item.author ? ` by ${item.author}` : "";
+  const location = item.url ? ` in ${item.url}` : "";
+  return `${prefix}${subject}${author}${location}`;
+}
+
+function itemPrefix(type) {
+  if (type === "fix") {
+    return "(Fix) ";
+  }
+  if (type === "perf") {
+    return "(Perf) ";
+  }
+  if (type === "test") {
+    return "(Test) ";
+  }
+  if (type === "docs") {
+    return "(Docs) ";
+  }
+  if (type === "refactor") {
+    return "(Refactor) ";
+  }
+  return "";
+}
+
+function cleanSubject(subject) {
+  return subject
+    .replace(/^add\b/i, "Added")
+    .replace(/^start\b/i, "Started")
+    .replace(/^split\b/i, "Split")
+    .replace(/^lower\b/i, "Lowered")
+    .replace(/^typecheck\b/i, "Typechecked")
+    .replace(/^type-check\b/i, "Type-checked")
+    .replace(/^resolve\b/i, "Resolved")
+    .replace(/^merge\b/i, "Merged")
+    .replace(/^complete\b/i, "Completed")
+    .replace(/^accept\b/i, "Accepted")
+    .replace(/^install\b/i, "Installed")
+    .replace(/^update\b/i, "Updated")
+    .replace(/^refresh\b/i, "Refreshed")
+    .replace(/^correct\b/i, "Corrected")
+    .replace(/^fix\b/i, "Fixed")
+    .replace(/^harden\b/i, "Hardened")
+    .replace(/^bundle\b/i, "Bundled")
+    .replace(/^generate\b/i, "Generated");
+}
+
+function sentenceCase(text) {
+  if (!text) {
+    return text;
+  }
+  return text[0].toUpperCase() + text.slice(1);
+}
+
+function fullChangelogLine(notes, version, repository) {
+  const match = notes.match(/\*\*Full Changelog\*\*: (https:\/\/github\.com\/[^\s]+)/);
+  if (!match) {
+    return `**Full Changelog**: https://github.com/${repository}/commits/v${version}`;
+  }
+
+  return match[0].replace(/v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/, `v${version}`);
+}
+
+function upsertChangelogEntry(filePath, version, entry) {
+  const intro = changelogIntro();
+  if (!fs.existsSync(filePath)) {
+    return {
+      status: "created",
+      content: `${intro}\n${entry}`,
+    };
+  }
+
+  const content = fs.readFileSync(filePath, "utf8");
+  const headingPattern = new RegExp(`^## v${escapeRegExp(version)}\\b.*$`, "m");
+  const heading = content.match(headingPattern);
+  if (!heading) {
+    const insertion = content.match(/^## v/m);
+    if (!insertion) {
+      return {
+        status: "appended",
+        content: `${content.trimEnd()}\n\n${entry}`,
+      };
+    }
+
+    return {
+      status: "inserted",
+      content: `${content.slice(0, insertion.index)}${entry}\n${content.slice(
+        insertion.index,
+      )}`,
+    };
+  }
+
+  const start = heading.index;
+  const nextHeading = content.slice(start + heading[0].length).match(/\n## v/);
+  const end = nextHeading
+    ? start + heading[0].length + nextHeading.index + 1
+    : content.length;
+  return {
+    status: "replaced",
+    content: `${content.slice(0, start)}${entry}${content.slice(end)}`,
+  };
+}
+
+function changelogIntro() {
+  return [
+    "# Change Log",
+    "",
+    'All notable changes to "EverMemoryArchive" will be documented in this file.',
+    "",
+  ].join("\n");
+}
+
+function today() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/scripts/release-preflight.mjs
+++ b/scripts/release-preflight.mjs
@@ -1,0 +1,273 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+
+const args = process.argv.slice(2);
+let targetArg = "";
+let outputJson = false;
+let write = false;
+
+for (const arg of args) {
+  if (arg === "--json") {
+    outputJson = true;
+    continue;
+  }
+
+  if (arg === "--write") {
+    write = true;
+    continue;
+  }
+
+  if (!targetArg) {
+    targetArg = arg;
+    continue;
+  }
+
+  usage(`Unexpected argument: ${arg}`);
+}
+
+if (!targetArg) {
+  usage("Missing target version");
+}
+
+const targetVersion = normalizeVersion(targetArg);
+validateVersion(targetVersion);
+
+const jsonVersionFiles = [
+  "package.json",
+  "packages/ema/package.json",
+  "packages/ema-webui/package.json",
+];
+
+const cargoPackages = [
+  { path: "packages/ema-dist/Cargo.toml", name: "ema-dist" },
+];
+
+let updates = inspectVersionUpdates();
+
+if (write) {
+  applyUpdates(updates);
+  updates = inspectVersionUpdates();
+}
+
+const result = {
+  targetVersion,
+  targetTag: `v${targetVersion}`,
+  releaseType: classifyReleaseType(targetVersion),
+  branch: currentBranch(),
+  changelog: inspectChangelog("CHANGELOG.md", targetVersion),
+  updates,
+  pendingUpdates: updates.filter((item) => item.currentVersion !== targetVersion),
+  commands: {
+    applyVersionUpdates: `node scripts/release-preflight.mjs v${targetVersion} --write`,
+    generateChangelog: `node scripts/generate-changelog.mjs v${targetVersion} --write`,
+    draftReleaseNotes: `node scripts/draft-release.mjs v${targetVersion}`,
+  },
+};
+
+if (outputJson) {
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+} else {
+  printHuman(result);
+}
+
+function usage(message) {
+  if (message) {
+    console.error(message);
+  }
+  console.error("Usage: node scripts/release-preflight.mjs <version> [--write] [--json]");
+  process.exit(1);
+}
+
+function normalizeVersion(version) {
+  return version.startsWith("v") ? version.slice(1) : version;
+}
+
+function validateVersion(version) {
+  if (/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(version)) {
+    return;
+  }
+
+  usage(`Invalid semver version: ${version}`);
+}
+
+function classifyReleaseType(version) {
+  return version.includes("-") ? "prerelease" : "stable";
+}
+
+function inspectVersionUpdates() {
+  return [
+    ...jsonVersionFiles.map((filePath) => inspectJsonVersion(filePath)),
+    ...cargoPackages.map((pkg) => inspectCargoVersion(pkg.path)),
+    ...cargoPackages.map((pkg) =>
+      inspectCargoLockVersion("packages/ema-dist/Cargo.lock", pkg.name),
+    ),
+  ].filter(Boolean);
+}
+
+function inspectJsonVersion(filePath) {
+  const content = readText(filePath);
+  const parsed = JSON.parse(content);
+  if (typeof parsed.version !== "string") {
+    return null;
+  }
+
+  return {
+    path: filePath,
+    kind: "json",
+    currentVersion: parsed.version,
+    nextVersion: targetVersion,
+  };
+}
+
+function inspectCargoVersion(filePath) {
+  const content = readText(filePath);
+  const match = content.match(/^version\s*=\s*"([^"]+)"/m);
+  if (!match) {
+    return null;
+  }
+
+  return {
+    path: filePath,
+    kind: "cargo-toml",
+    currentVersion: match[1],
+    nextVersion: targetVersion,
+  };
+}
+
+function inspectCargoLockVersion(filePath, packageName) {
+  const content = readText(filePath);
+  const blockPattern = new RegExp(
+    `(\\[\\[package\\]\\]\\nname = "${escapeRegExp(packageName)}"\\nversion = ")([^"]+)(")`,
+  );
+  const match = content.match(blockPattern);
+  if (!match) {
+    return null;
+  }
+
+  return {
+    path: filePath,
+    kind: "cargo-lock",
+    packageName,
+    currentVersion: match[2],
+    nextVersion: targetVersion,
+  };
+}
+
+function applyUpdates(items) {
+  const byPath = new Map();
+  for (const item of items) {
+    if (item.currentVersion === targetVersion) {
+      continue;
+    }
+
+    const group = byPath.get(item.path) ?? [];
+    group.push(item);
+    byPath.set(item.path, group);
+  }
+
+  for (const [filePath, fileUpdates] of byPath) {
+    const first = fileUpdates[0];
+    if (first.kind === "json") {
+      writeJsonVersion(filePath);
+      continue;
+    }
+
+    if (first.kind === "cargo-toml") {
+      writeCargoTomlVersion(filePath);
+      continue;
+    }
+
+    if (first.kind === "cargo-lock") {
+      writeCargoLockVersions(filePath, fileUpdates);
+      continue;
+    }
+  }
+}
+
+function writeJsonVersion(filePath) {
+  const parsed = JSON.parse(readText(filePath));
+  parsed.version = targetVersion;
+  fs.writeFileSync(filePath, `${JSON.stringify(parsed, null, 2)}\n`, "utf8");
+}
+
+function writeCargoTomlVersion(filePath) {
+  const next = readText(filePath).replace(
+    /^version\s*=\s*"[^"]+"/m,
+    `version = "${targetVersion}"`,
+  );
+  fs.writeFileSync(filePath, next, "utf8");
+}
+
+function writeCargoLockVersions(filePath, fileUpdates) {
+  let next = readText(filePath);
+  for (const item of fileUpdates) {
+    const blockPattern = new RegExp(
+      `(\\[\\[package\\]\\]\\nname = "${escapeRegExp(item.packageName)}"\\nversion = ")[^"]+(")`,
+    );
+    next = next.replace(blockPattern, `$1${targetVersion}$2`);
+  }
+  fs.writeFileSync(filePath, next, "utf8");
+}
+
+function inspectChangelog(filePath, version) {
+  if (!fs.existsSync(filePath)) {
+    return {
+      path: filePath,
+      status: "missing",
+      heading: null,
+    };
+  }
+
+  const content = readText(filePath);
+  const headingPattern = new RegExp(`^## v${escapeRegExp(version)}\\b`, "m");
+  const match = content.match(headingPattern);
+  return {
+    path: filePath,
+    status: match ? "present" : "missing-entry",
+    heading: match?.[0] ?? null,
+  };
+}
+
+function currentBranch() {
+  try {
+    return execFileSync("git", ["branch", "--show-current"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return "";
+  }
+}
+
+function readText(filePath) {
+  return fs.readFileSync(filePath, "utf8");
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function printHuman(result) {
+  console.log(`Target: ${result.targetTag} (${result.releaseType})`);
+  console.log(`Branch: ${result.branch || "(unknown)"}`);
+  console.log(`Changelog: ${result.changelog.status}`);
+  console.log("");
+
+  if (result.pendingUpdates.length === 0) {
+    console.log("Version strings are already up to date.");
+  } else {
+    console.log("Pending version updates:");
+    for (const item of result.pendingUpdates) {
+      const label = item.packageName ? `${item.path} (${item.packageName})` : item.path;
+      console.log(`- ${label}: ${item.currentVersion} -> ${item.nextVersion}`);
+    }
+  }
+
+  console.log("");
+  console.log("Commands:");
+  console.log(`- ${result.commands.applyVersionUpdates}`);
+  console.log(`- ${result.commands.generateChangelog}`);
+  console.log(`- ${result.commands.draftReleaseNotes}`);
+}


### PR DESCRIPTION
## Summary

- add release preflight, changelog generation, and draft release note scripts
- emit SHA-256 sidecar files for archives and installers
- publish tagged distribution artifacts through a GitHub draft release workflow path

## Checks

- pnpm format:check
- pnpm --filter ema-dist exec tsc --noEmit -p tsconfig.json
- node scripts/release-preflight.mjs v1.0.0-beta.1 --json