### PR TITLE
Fix/create-actor flat viewport

### DIFF
--- a/packages/ema-webui/src/features/create-actor/components/create-actor.module.css
+++ b/packages/ema-webui/src/features/create-actor/components/create-actor.module.css
@@ -197,11 +197,11 @@
     14px
     142px
     154px
-    500px
+    minmax(0, 1fr)
     88px
     14px;
   width: min(100% - 36px, 920px);
-  height: auto;
+  height: min(912px, calc(100dvh - 24px));
   min-height: 0;
   overflow: hidden;
   padding: 0;

--- a/packages/ema-webui/src/features/create-actor/components/create-actor.module.css
+++ b/packages/ema-webui/src/features/create-actor/components/create-actor.module.css
@@ -432,7 +432,7 @@
   min-height: 0;
   min-width: 0;
   justify-items: center;
-  align-content: center;
+  align-content: safe center;
   overflow-y: auto;
   padding: 18px 4px;
   scrollbar-color: color-mix(in srgb, var(--text-subtle) 58%, transparent)
@@ -627,7 +627,7 @@
   grid-template-rows: auto 1fr;
   gap: 12px;
   min-width: 0;
-  min-height: 156px;
+  min-height: 0;
   padding: 18px 16px 16px;
   border: 0;
   background: transparent;

--- a/packages/ema-webui/src/features/create-actor/components/create-actor.module.css
+++ b/packages/ema-webui/src/features/create-actor/components/create-actor.module.css
@@ -603,13 +603,17 @@
 .createActorSourceGrid {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-rows: minmax(0, 1fr);
   gap: 14px;
   width: min(100%, 640px);
+  height: 100%;
+  max-height: 156px;
 }
 
 .createActorSourceCard {
   position: relative;
   display: grid;
+  grid-template-rows: minmax(0, 1fr);
   min-width: 0;
   border-radius: 16px;
   overflow: hidden;


### PR DESCRIPTION
Modified the create-actor interface; the "继续" button will no longer be hidden when the height is insufficient.